### PR TITLE
Accept WRITE flag in 'open' sftp call. 

### DIFF
--- a/asyncssh/sftp.py
+++ b/asyncssh/sftp.py
@@ -2757,6 +2757,9 @@ class SFTPServerSession(SFTPSession, SSHServerSession):
 
     _open_modes = {
         FXF_READ:                                      'rb',
+        FXF_WRITE:                                     'wb',
+        FXF_WRITE | FXF_CREAT:                         'wb',
+        FXF_WRITE | FXF_EXCL:                          'xb',
         FXF_WRITE | FXF_CREAT | FXF_TRUNC:             'wb',
         FXF_WRITE | FXF_CREAT | FXF_APPEND:            'ab',
         FXF_WRITE | FXF_CREAT | FXF_EXCL:              'xb',


### PR DESCRIPTION
The sshfs tools (using Ubuntu) sends the WRITE flag only when creating/copying files.
I literally receive the value ``2``.

First, ``SFTPError(FX_FAILURE, 'Unsupported open flags')`` was raised.