### PR TITLE
Fix a bug in keyboard-interactive auth

### DIFF
--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -1958,6 +1958,8 @@ class SSHClientConnection(SSHConnection):
                 result = []
             elif len(prompts) == 1 and 'password' in prompts[0][0].lower():
                 password = self.password_auth_requested()
+                if asyncio.iscoroutine(password):
+                    password = yield from password
                 result = [password] if password is not None else None
             else:
                 result = None


### PR DESCRIPTION
When fetching the password during keyboard interactive auth we did not handle
the case of SSHClientConnection.password_auth_requested being a coroutine,
meaning that where we were expecting a password string we would under some/all
circumstances have a generator instead.