### PR TITLE
important issue: to append a general object to factory instance once it is created

### DIFF
--- a/asyncssh/channel.py
+++ b/asyncssh/channel.py
@@ -790,7 +790,7 @@ class SSHClientChannel(SSHChannel):
 
     @asyncio.coroutine
     def create(self, session_factory, command, subsystem, env,
-               term_type, term_size, term_modes, agent_forwarding):
+               term_type, term_size, term_modes, agent_forwarding, factory_obj_append):
         """Create an SSH client session"""
 
         packet = yield from self._open(b'session')
@@ -799,6 +799,7 @@ class SSHClientChannel(SSHChannel):
         packet.check_end()
 
         self._session = session_factory()
+        self._session.factory_obj_append = factory_obj_append
         self._session.connection_made(self)
 
         for name, value in env.items():

--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -1941,7 +1941,7 @@ class SSHClientConnection(SSHConnection):
     def __init__(self, client_factory, loop, kex_algs, encryption_algs,
                  mac_algs, compression_algs, rekey_bytes, rekey_seconds,
                  host, port, known_hosts, username, password, client_keys,
-                 agent, agent_path, auth_waiter):
+                 agent, agent_path, auth_waiter, factory_obj_append=None):
         super().__init__(client_factory, loop, kex_algs, encryption_algs,
                          mac_algs, compression_algs, rekey_bytes,
                          rekey_seconds, server=False)
@@ -1955,6 +1955,7 @@ class SSHClientConnection(SSHConnection):
         self._agent = agent
         self._agent_path = agent_path
         self._auth_waiter = auth_waiter
+        self._factory_obj_append = factory_obj_append
 
         self._server_host_keys = set()
         self._server_ca_keys = set()
@@ -2398,7 +2399,7 @@ class SSHClientConnection(SSHConnection):
 
         return (yield from chan.create(session_factory, command, subsystem,
                                        env, term_type, term_size, term_modes,
-                                       bool(self._agent_path)))
+                                       bool(self._agent_path), self._factory_obj_append))
 
     @asyncio.coroutine
     def open_session(self, *args, **kwargs):
@@ -3863,7 +3864,7 @@ def create_connection(client_factory, host, port=_DEFAULT_PORT, *,
                       agent_path=(), agent_forwarding=False, kex_algs=(),
                       encryption_algs=(), mac_algs=(), compression_algs=(),
                       rekey_bytes=_DEFAULT_REKEY_BYTES,
-                      rekey_seconds=_DEFAULT_REKEY_SECONDS):
+                      rekey_seconds=_DEFAULT_REKEY_SECONDS, factory_obj_append=None):
     """Create an SSH client connection
 
        This function is a coroutine which can be run to create an outbound SSH
@@ -4006,7 +4007,7 @@ def create_connection(client_factory, host, port=_DEFAULT_PORT, *,
                                    encryption_algs, mac_algs, compression_algs,
                                    rekey_bytes, rekey_seconds, host, port,
                                    known_hosts, username, password,
-                                   client_keys, agent, agent_path, auth_waiter)
+                                   client_keys, agent, agent_path, auth_waiter, factory_obj_append)
 
     if not client_factory:
         client_factory = SSHClient


### PR DESCRIPTION
important issue: to append a general object to session factory instance once it is created synchronizedly,

otherwise, "asyncssh.SSHClientSession.data_received" might get access to a object which haven't been setting the expected value:

...
...
  def data_received(self, data, datatype):
    self._websocket.send(data)                    ## Line A
...
...

...
...
  chan, session = yield from conn.create_session(MySSHClientSession, 'bash', term_type='xterm', term_size=(80, 24))
  session._websocket = websocket_map[userid]      ## Line B
...
...

Line A might run before Line B, making error exception for a certain possiblity

====================================

After using this patch, it will work well and no more exception

...
...
  def session_started(self):
    extract_data = self._factory_obj_append
    self._websocket = extract_data[0]

  def data_received(self, data, datatype):
    self._websocket.send(data)
...
...

...
...
  conn, client = yield from asyncssh.create_connection(MySSHClient, hostname, username=username, port=int(s_port), password=password, known_hosts=None, factory_obj_append=(_websocket, ..))
..
  chan, session = yield from conn.create_session(MySSHClientSession, 'bash', term_type='xterm', term_size=(80, 24))
...
...

====================================

This feature is useful to implement websocket + asyncssh = webssh

Signed-off-by: cuiwei13 <cuiwei13@pku.edu.cn>