### PR TITLE
Fix typos in documentation

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -72,7 +72,7 @@ There are two long-lived branches in AsyncSSH at the moment:
 
 * The master branch is intended to contain the latest stable version
   of the code. All official versions of AsyncSSH are released from
-  this branch, and a each release has a corresponding tag added
+  this branch, and each release has a corresponding tag added
   matching its release number. Bug fixes and simple improvements
   may be checked directly into this branch, but most new features
   will be added to the develop branch first.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -93,7 +93,7 @@ as arguments which manage the channels once they are open.
 
 To better support interactive server applications, AsyncSSH defaults to
 providing echoing of input and basic line editing capabilities when an
-inbound SSH session requests a psuedo-terminal. This behavior can be
+inbound SSH session requests a pseudo-terminal. This behavior can be
 disabled by setting the ``line_editor`` argument to ``False`` when
 starting up an SSH server. When this feature is enabled, server sessions
 can enable or disable line mode using the :meth:`set_line_mode()
@@ -998,7 +998,7 @@ file constructed by appending '-cert.pub' to the end of the name.
 Encrypted private keys can be loaded by making an explicit call to
 :func:`import_private_key` or :func:`read_private_key` with the
 correct passphrase. The resulting :class:`SSHKey` objects can then
-be included in thie list, each with an optional matching certificate.
+be included in the list, each with an optional matching certificate.
 
 New private keys can be generated using the :func:`generate_private_key`
 function. The resulting :class:`SSHKey` objects have methods which can

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -26,7 +26,7 @@ Release 1.6.1 (27 Aug 2016)
 
 * Fixed a race condition in SFTP unit tests.
 
-* Updated dependencie to require version 1.5 of the cryptography module
+* Updated dependencies to require version 1.5 of the cryptography module
   and started to take advantage of the new one-shot sign and verify
   APIs it now supports.
 
@@ -286,7 +286,7 @@ Release 1.3.1 (6 Nov 2015)
 
 * Updated AsyncSSH to depend on version 1.1 or later of PyCA and added
   support for using its new Elliptic Curve Diffie Hellman (ECDH)
-  implementation, replacing the the previous AsyncSSH native Python
+  implementation, replacing the previous AsyncSSH native Python
   version.
 
 * Added support for specifying a passphrase in the create_connection,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -316,7 +316,7 @@ SFTP client
 -----------
 
 AsyncSSH also provides SFTP support. The following code shows an example
-of starting an SFTP client and requestng the download of a file:
+of starting an SFTP client and requesting the download of a file:
 
    .. include:: ../examples/sftp_client.py
       :literal:


### PR DESCRIPTION
Found using [mwic](http://jwilk.net/software/mwic) and [anorack](https://github.com/jwilk/anorack).