### PR TITLE
tests: discard ssh-agent error output

### DIFF
--- a/tests/server.py
+++ b/tests/server.py
@@ -110,7 +110,7 @@ class ServerTestCase(AsyncTestCase):
                                                       cls._server_port))
         run('cat skey.pub >> .ssh/known_hosts')
 
-        output = run('ssh-agent -a agent')
+        output = run('ssh-agent -a agent 2> /dev/null')
         cls._agent_pid = int(output.splitlines()[2].split()[3][:-1])
 
         os.environ['SSH_AUTH_SOCK'] = 'agent'

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -78,7 +78,7 @@ class _TestAPI(AsyncTestCase):
 
         run('ssh-keygen -q -b 2048 -t rsa -N "" -f ckey')
 
-        output = run('ssh-agent -a agent')
+        output = run('ssh-agent -a agent 2> /dev/null')
         cls._agent_pid = int(output.splitlines()[2].split()[3][:-1])
 
         os.environ['SSH_AUTH_SOCK'] = 'agent'


### PR DESCRIPTION
ssh-agent being a setgid program, it is possible the linker complain
about not being able to preload a library specified in `LD_PRELOAD`
environment variable. This can happen when people are using `eatmydata`,
a program disabling `sync()` and friends to speed up compilation.