### PR TITLE
Fix SSH connection with known hosts object.

### DIFF
--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -1966,10 +1966,20 @@ class SSHClientConnection(SSHConnection):
                 server_host_keys, server_ca_keys, revoked_server_keys = \
                     match_known_hosts(self._known_hosts, self._host,
                                       self._peer_addr, self._port)
-            else:
+
+            # Duck typing SSHKnownHosts.
+            elif hasattr(self._known_hosts, 'match'):
                 server_host_keys, server_ca_keys, revoked_server_keys = \
                     self._known_hosts.match(self._host, self._peer_addr,
                                             self._port)
+
+                server_host_keys = load_public_keys(server_host_keys)
+                server_ca_keys = load_public_keys(server_ca_keys)
+                revoked_server_keys = load_public_keys(revoked_server_keys)
+
+            else:
+                server_host_keys, server_ca_keys, revoked_server_keys = \
+                    self._known_hosts
 
                 server_host_keys = load_public_keys(server_host_keys)
                 server_ca_keys = load_public_keys(server_ca_keys)

--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -1968,7 +1968,8 @@ class SSHClientConnection(SSHConnection):
                                       self._peer_addr, self._port)
             else:
                 server_host_keys, server_ca_keys, revoked_server_keys = \
-                    self._known_hosts
+                    self._known_hosts.match(self._host, self._peer_addr,
+                                            self._port)
 
                 server_host_keys = load_public_keys(server_host_keys)
                 server_ca_keys = load_public_keys(server_ca_keys)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -342,6 +342,29 @@ class _TestConnection(ServerTestCase):
         yield from conn.wait_closed()
 
     @asynctest
+    def test_read_known_hosts(self):
+        """Test connecting with known hosts object from 'read_known_hosts'"""
+
+        obj = asyncssh.read_known_hosts('.ssh/known_hosts')
+
+        with (yield from self.connect(known_hosts=obj)) as conn:
+            pass
+
+        yield from conn.wait_closed()
+
+    @asynctest
+    def test_import_known_hosts(self):
+        """Test connecting with known hosts object from 'import_known_hosts'"""
+
+        with open('.ssh/known_hosts', 'r') as known_hosts:
+            obj = asyncssh.import_known_hosts(known_hosts.read())
+
+            with (yield from self.connect(known_hosts=obj)) as conn:
+                pass
+
+            yield from conn.wait_closed()
+
+    @asynctest
     def test_known_hosts_sshkeys(self):
         """Test connecting with known hosts passed in as SSHKeys"""
 


### PR DESCRIPTION
The connection was failing when the `known_hosts` parameter was a `SSHKnownHosts` object previously imported from a string by calling `import_known_hosts()`, as documented [here](http://asyncssh.readthedocs.io/en/latest/api.html#specifying-known-hosts).

Python was throwing an exception since the `SSHKnownHosts` object was not "unpackable". Using the `self._known_hosts.match` method, which returns the proper tuple, appears to fix the error.