### PR TITLE
Add two test cases for known_hosts

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -371,6 +371,29 @@ class _TestConnection(ServerTestCase):
         yield from conn.wait_closed()
 
     @asynctest
+    def test_read_known_hosts(self):
+        """Test connecting with known hosts object from 'read_known_hosts'"""
+
+        obj = asyncssh.read_known_hosts('.ssh/known_hosts')
+
+        with (yield from self.connect(known_hosts=obj)) as conn:
+            pass
+
+        yield from conn.wait_closed()
+
+    @asynctest
+    def test_import_known_hosts(self):
+        """Test connecting with known hosts object from 'import_known_hosts'"""
+
+        with open('.ssh/known_hosts', 'r') as known_hosts:
+            obj = asyncssh.import_known_hosts(known_hosts.read())
+
+            with (yield from self.connect(known_hosts=obj)) as conn:
+                pass
+
+            yield from conn.wait_closed()
+
+    @asynctest
     def test_untrusted_known_hosts_key(self):
         """Test untrusted server host key"""
 


### PR DESCRIPTION
Ron you might wan't to add these two test cases I wrote on #88 to help prevent the new known_hosts features do not regress.

I just ran them on version 1.10.0 and they went ok.