### PR TITLE
Bug remote listener doesn't close

### DIFF
--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -2445,7 +2445,7 @@ class SSHClientConnection(SSHConnection):
         """Close a remote TCP/IP listener"""
 
         yield from self._make_global_request(
-            b'cancel-tcpip-forward', String(listen_host), UInt32(listen_port))
+            b'cancel-tcpip-forward', listen_host.encode(), UInt32(listen_port))
 
         self.logger.info('Closed remote TCP listener on %s',
                          (listen_host, listen_port))

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -660,16 +660,17 @@ class _TestTCPForwarding(_CheckForwarding):
         with (yield from self.connect()) as conn:
             listener = yield from conn.forward_remote_port('', 0, '',
                                                            server_port)
-
+        
             yield from self._check_local_connection(listener.get_port())
-
+            used_port = listener.get_port()
             listener.close()
             yield from listener.wait_closed()
             # Verify the port is available again.            
-            listener = yield from conn.forward_remote_port('', 0, '',
+            listener = yield from conn.forward_remote_port('', used_port, '',
                                                            server_port)
-            
-            yield from self._check_local_connection(listener.get_port())
+            self.assertIsNotNone(listener)
+            yield from listener.close()
+            yield from listener.wait_closed()
 
         yield from conn.wait_closed()
 

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -665,7 +665,9 @@ class _TestTCPForwarding(_CheckForwarding):
             used_port = listener.get_port()
             listener.close()
             yield from listener.wait_closed()
+            
             # Verify the port is available again.            
+            yield from asyncio.sleep(0.5)
             listener = yield from conn.forward_remote_port('', used_port, '',
                                                            server_port)
             self.assertIsNotNone(listener)

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -668,10 +668,10 @@ class _TestTCPForwarding(_CheckForwarding):
             
             # Verify the port is available again.            
             yield from asyncio.sleep(0.5)
-            listener = yield from conn.forward_remote_port('', used_port, '',
-                                                           server_port)
+            new_server = yield from asyncio.start_server(echo, None, used_port)
+
             self.assertIsNotNone(listener)
-            yield from listener.close()
+            new_server.close()
             yield from listener.wait_closed()
 
         yield from conn.wait_closed()


### PR DESCRIPTION
Closes #145 
with a binary SSH server the fix works, but with the current asyncssh implementation it doesn't work.
I've looked at the  [SSH RFC](https://tools.ietf.org/rfc/rfc4254.txt) and according to page 16, the local host should be passed as a string(bytes, in python 3).
Currently the `String` method return something like this:
```
In [3]: String("127.0.0.1")
Out[3]: b'\x00\x00\x00\t127.0.0.1'
```
When I checked it against my ssh server it didn't work(both openssh and dropbear implementations), but with my fix it did work.
I see that the "tcpip-forward" is working, but I don't really understand how.