### PR TITLE
Guard some imports and tests for Fedora 27

### DIFF
--- a/tests/sspi_stub.py
+++ b/tests/sspi_stub.py
@@ -12,8 +12,12 @@
 
 """Stub SSPI module for unit tests"""
 
-from asyncssh.gss_win32 import ASC_RET_INTEGRITY, ISC_RET_INTEGRITY
-from asyncssh.gss_win32 import SECPKG_ATTR_NATIVE_NAMES, SSPIError
+import sys
+# on non-windows systems, work around setup.py test discovery
+# importing everything
+if sys.platform == 'win32':
+    from asyncssh.gss_win32 import ASC_RET_INTEGRITY, ISC_RET_INTEGRITY
+    from asyncssh.gss_win32 import SECPKG_ATTR_NATIVE_NAMES, SSPIError
 
 from .gss_stub import step
 

--- a/tests/test_public_key.py
+++ b/tests/test_public_key.py
@@ -26,6 +26,7 @@ from pathlib import Path
 import shutil
 import subprocess
 import sys
+import unittest
 
 import asyncssh
 
@@ -1968,11 +1969,15 @@ class _TestPublicKeyTopLevel(TempDirTestCase):
                         '-param_enc explicit' % curve)
                     asyncssh.read_private_key('priv')
 
-            with self.subTest('Import EC key with unknown explicit parameters'):
-                run('openssl ecparam -out priv -noout -genkey -name secp112r1 '
-                    '-param_enc explicit')
-                with self.assertRaises(asyncssh.KeyImportError):
-                    asyncssh.read_private_key('priv')
+    @unittest.skipIf(b'secp224r1' not in run('openssl ecparam -list_curves'),
+            "this openssl doesn't support secp224r1")
+    @unittest.skipIf(not _openssl_available, "openssl isn't available")
+    def test_ec_explicit_unk(self):
+        """Import EC key with unknown explicit parameters"""
+        run('openssl ecparam -out priv -noout -genkey -name secp224r1 '
+            '-param_enc explicit')
+        with self.assertRaises(asyncssh.KeyImportError):
+                asyncssh.read_private_key('priv')
 
     def test_generate_errors(self):
         """Test errors in private key and certificate generation"""


### PR DESCRIPTION
such that `python3 setup.py test` executes successfully.

Background: I'm packaging asyncssh for Fedora. And in that process I noticed some test cases failing.