### PR TITLE
Use the default known_hosts file only if it exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 MANIFEST
 __pycache__/
 *.py[cod]
+.tox
 
 asyncssh.egg-info
 build/

--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -2230,8 +2230,10 @@ class SSHClientConnection(SSHConnection):
             self._trusted_ca_keys = None
         else:
             if not self._known_hosts:
-                self._known_hosts = os.path.join(os.path.expanduser('~'),
-                                                 '.ssh', 'known_hosts')
+                default_known_hosts = os.path.join(os.path.expanduser('~'),
+                                                   '.ssh', 'known_hosts')
+                if os.path.isfile(default_known_hosts):
+                    self._known_hosts = default_known_hosts
 
             port = self._port if self._port != _DEFAULT_PORT else None
 


### PR DESCRIPTION
Currently the code makes the assumption that a default `.ssh/known_hosts` exists, which is not always case (especially when using the official Python docker containers). 