### PR TITLE
Optimize SFTP glob matching

### DIFF
--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -771,6 +771,9 @@ class _TestSFTP(_CheckSFTP):
             self._create_file('file1')
             self._create_file('filedir/file2')
             self._create_file('filedir/file3')
+            os.mkdir('filedir/filedir2')
+            self._create_file('filedir/filedir2/file4')
+            self._create_file('filedir/filedir2/file5')
 
             self.assertEqual(sorted((yield from sftp.glob('file*'))),
                              ['file1', 'filedir'])
@@ -783,15 +786,43 @@ class _TestSFTP(_CheckSFTP):
             self.assertEqual(sorted((yield from sftp.glob(['', 'file*']))),
                              ['file1', 'filedir'])
             self.assertEqual(sorted((yield from sftp.glob(['file*/*2']))),
-                             ['filedir/file2'])
+                             ['filedir/file2', 'filedir/filedir2'])
             self.assertEqual(sorted((yield from sftp.glob(['file*/*[3-9]']))),
                              ['filedir/file3'])
             self.assertEqual(sorted((yield from sftp.glob(['**/file[12]']))),
                              ['file1', 'filedir/file2'])
             self.assertEqual(sorted((yield from sftp.glob(['**/file*/']))),
-                             ['filedir'])
+                             ['filedir', 'filedir/filedir2'])
             self.assertEqual((yield from sftp.glob([b'fil*1', 'fil*dir'])),
                              [b'file1', 'filedir'])
+            self.assertEqual(sorted((yield from sftp.glob('filedir/file2'))),
+                             ['filedir/file2'])
+            self.assertEqual(sorted((yield from sftp.glob('./filedir/file2'))),
+                             ['./filedir/file2'])
+            self.assertEqual(sorted((yield from sftp.glob('filedir/file*'))),
+                             ['filedir/file2','filedir/file3', 'filedir/filedir2'])
+            self.assertEqual(sorted((yield from sftp.glob('./filedir/file*'))),
+                             ['./filedir/file2','./filedir/file3', './filedir/filedir2'])
+            self.assertEqual(sorted((yield from sftp.glob('./filedir/filedir2/file*'))),
+                            ['./filedir/filedir2/file4','./filedir/filedir2/file5'])
+            self.assertEqual(sorted((yield from sftp.glob('filedir/filedir2/file*'))),
+                            ['filedir/filedir2/file4','filedir/filedir2/file5'])
+            self.assertEqual(sorted((yield from sftp.glob('./filedir/*/file4'))),
+                            ['./filedir/filedir2/file4'])
+            self.assertEqual(sorted((yield from sftp.glob('filedir/*/file4'))),
+                            ['filedir/filedir2/file4'])
+            self.assertEqual(sorted((yield from sftp.glob('./*/filedir2/file4'))),
+                            ['./filedir/filedir2/file4'])
+            self.assertEqual(sorted((yield from sftp.glob('*/filedir2/file4'))),
+                            ['filedir/filedir2/file4'])
+            self.assertEqual(sorted((yield from sftp.glob('./filedir/filedir*/file*'))),
+                            ['./filedir/filedir2/file4','./filedir/filedir2/file5'])
+            self.assertEqual(sorted((yield from sftp.glob('filedir/filedir*/file*'))),
+                            ['filedir/filedir2/file4','filedir/filedir2/file5'])
+            self.assertEqual(sorted((yield from sftp.glob('./**/filedir2/file4'))),
+                            ['./filedir/filedir2/file4'])
+            self.assertEqual(sorted((yield from sftp.glob('**/filedir2/file4'))),
+                            ['filedir/filedir2/file4'])
         finally:
             remove('file1 filedir')
 


### PR DESCRIPTION
This commit reduces number of calls to listdir() if glob pattern
contains directory names without glob characters. This could improve
performance significantly if the network latency is high and/or the
intermediate directories have big number of entries.

For example before this commit the pattern "/usr/share/doc/qt5/global/*"
resulted in six listdir() calls but with this commit only one call is
needed. And the total number of returned entries reduced from more
than 1.5K to just couple of dozen in my case.

An additional bonus is that with this commit the case when mount point
of the auto-mounted directory is used without glob characters in the
pattern then it is processed correctly.