### PR TITLE
Allow PurePath for the single file source argument in SFTP get, put and copy

### DIFF
--- a/asyncssh/sftp.py
+++ b/asyncssh/sftp.py
@@ -2037,7 +2037,7 @@ class SFTPClient:
         if dstpath:
             dstpath = dstfs.encode(dstpath)
 
-        if isinstance(srcpaths, (str, bytes)):
+        if isinstance(srcpaths, (str, bytes, PurePath)):
             srcpaths = [srcpaths]
         elif not dst_isdir:
             raise SFTPError(FX_FAILURE, '%s must be a directory' %

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -533,13 +533,14 @@ class _TestSFTP(_CheckSFTP):
         """Test copying a file over SFTP"""
 
         for method in ('get', 'put', 'copy'):
-            with self.subTest(method=method):
-                try:
-                    self._create_file('src')
-                    yield from getattr(sftp, method)('src', 'dst')
-                    self._check_file('src', 'dst')
-                finally:
-                    remove('src dst')
+            for src in ('src', b'src', Path('src')):
+                with self.subTest(method=method, src=type(src)):
+                    try:
+                        self._create_file('src')
+                        yield from getattr(sftp, method)(src, 'dst')
+                        self._check_file('src', 'dst')
+                    finally:
+                        remove('src dst')
 
     @sftp_test
     def test_copy_progress(self, sftp):


### PR DESCRIPTION
PurePath was missing in the check if source is a single file.