### PR TITLE
Allow PurePath for the source and target arguments in scp

### DIFF
--- a/asyncssh/scp.py
+++ b/asyncssh/scp.py
@@ -25,6 +25,7 @@
 import argparse
 import asyncio
 import posixpath
+from pathlib import PurePath
 import shlex
 import stat
 
@@ -69,7 +70,7 @@ def _parse_path(path, **kwargs):
         conn, path = path.split(':')
     elif isinstance(path, bytes) and b':' in path:
         conn, path = path.split(b':')
-    elif isinstance(path, (str, bytes)):
+    elif isinstance(path, (str, bytes, PurePath)):
         conn = None
     else:
         conn = path
@@ -90,6 +91,9 @@ def _parse_path(path, **kwargs):
 @asyncio.coroutine
 def _start_remote(conn, source, must_be_dir, preserve, recurse, path):
     """Start remote SCP server"""
+
+    if isinstance(path, PurePath):
+        path = str(path)
 
     if isinstance(path, str):
         path = path.encode('utf-8')

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -2743,12 +2743,15 @@ class _TestSCP(_CheckSCP):
     def test_get(self):
         """Test getting a file over SCP"""
 
-        try:
-            self._create_file('src')
-            yield from scp((self._scp_server, 'src'), 'dst')
-            self._check_file('src', 'dst')
-        finally:
-            remove('src dst')
+        for src in ('src', b'src', Path('src')):
+            for dst in ('dst', b'dst', Path('dst')):
+                with self.subTest(src=type(src), dst=type(dst)):
+                    try:
+                        self._create_file('src')
+                        yield from scp((self._scp_server, src), dst)
+                        self._check_file('src', 'dst')
+                    finally:
+                        remove('src dst')
 
     @asynctest
     def test_get_bytes_path(self):


### PR DESCRIPTION
Using PurePath is the only way to use paths with a drive letter
on Windows.