### PR TITLE
channel: Make check for None explicit

### DIFF
--- a/asyncssh/channel.py
+++ b/asyncssh/channel.py
@@ -185,7 +185,7 @@ class SSHChannel(SSHPacketHandler):
 
             self._request_waiters = []
 
-        if self._session:
+        if self._session is not None:
             self._session.connection_lost(exc)
             self._session = None
 
@@ -329,7 +329,7 @@ class SSHChannel(SSHPacketHandler):
             except UnicodeDecodeError as unicode_exc:
                 raise ProtocolError(str(unicode_exc)) from None
 
-        if self._session:
+        if self._session is not None:
             self._session.data_received(data, datatype)
 
     def _accept_data(self, data, datatype=None):
@@ -1824,7 +1824,7 @@ class SSHForwardChannel(SSHChannel):
 
         await super()._finish_open_request(session)
 
-        if self._session:
+        if self._session is not None:
             self._session.session_started()
             self.resume_reading()
 


### PR DESCRIPTION
I’m trying to write a [connector](https://github.com/aio-libs/aiohttp/blob/master/aiohttp/connector.py) for aiohttp, which SSH’s into a machine and then connects to a local UNIX domain socket on that host. While debugging why my BaseProtocol’s .data_received method was never called I noticed that SSHChannel._deliver_data implicitly checks self._session’s truth value, but not whether it is None. Since the BaseProtocol implements \_\_len\_\_, which can be zero, no data is forwarded to the callback.