### PR TITLE
handle `SSHServer.server_requested` Bool returns

### DIFF
--- a/asyncssh/server.py
+++ b/asyncssh/server.py
@@ -784,8 +784,8 @@ class SSHServer:
            :returns: One of the following:
 
                      * An :class:`SSHListener` object or a coroutine
-                       which returns an :class:`SSHListener` or `False`
-                       if the listener can't be opened
+                       which returns an :class:`SSHListener`, `True`
+                       or `False` if the listener can't be opened
                      * `True` to set up standard port forwarding
                      * `False` to reject the request
 

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -167,6 +167,18 @@ class _TCPConnectionServer(Server):
             return listen_host != 'fail'
 
 
+class _TCPAsyncConnectionServer(_TCPConnectionServer):
+    """Server for testing async direct and forwarded TCP connections"""
+
+    async def server_requested(self, listen_host, listen_port):
+        """Handle a request to create a new socket listener"""
+
+        if listen_host == 'open':
+            return _EchoPortListener(self._conn)
+        else:
+            return listen_host != 'fail'
+
+
 class _UNIXConnectionServer(Server):
     """Server for testing direct and forwarded UNIX domain connections"""
 
@@ -645,6 +657,18 @@ class _TestTCPForwarding(_CheckForwarding):
             for listener in listeners:
                 listener.close()
                 await listener.wait_closed()
+
+
+class _TestAsyncTCPForwarding(_TestTCPForwarding):
+    """Unit tests for AsyncSSH TCP connection forwarding with awaitable return"""
+
+    @classmethod
+    async def start_server(cls):
+        """Start an SSH server which supports TCP connection forwarding"""
+
+        return (await cls.create_server(
+            _TCPAsyncConnectionServer, authorized_client_keys='authorized_keys'))
+
 
 
 @unittest.skipIf(sys.platform == 'win32',


### PR DESCRIPTION
`SSHServer.server_requested` is documented to allow a coroutine return, but prior to this commit a return of False from the coroutine bypassed the code that handles the synchronous version.

Further, adding `True` to the async flow proved trivial and so that is done too.

This is my first PR here so I'm adding that, if accepted, I'm happy to contribute this change under the Eclipse Public License v2.0 and that I'm leaving how/if you list me in the contributors list entirely up to you.