### PR TITLE
Add support for ip_switch file xfer code

### DIFF
--- a/asyncssh/constants.py
+++ b/asyncssh/constants.py
@@ -143,7 +143,7 @@ FILEXFER_ATTR_UIDGID                = 0x00000002
 FILEXFER_ATTR_PERMISSIONS           = 0x00000004
 FILEXFER_ATTR_ACMODTIME             = 0x00000008
 FILEXFER_ATTR_EXTENDED              = 0x80000000
-FILEXFER_ATTR_UNDEFINED             = 0x7ffffff0
+FILEXFER_ATTR_UNDEFINED             = 0x7fffffc0
 
 # OpenSSH statvfs attribute flags
 FXE_STATVFS_ST_RDONLY               = 0x1


### PR DESCRIPTION
asyncssh (sftp) was failing for me when communicating with ip_switch SFTP server.  The failure occurred during the SFTPAttrs.decode method on line 855 when a flag value of 0x0000003d was received from the ip_switch SFTP server. afaict code 0x0000003d (dec 61) is a valid non-error code (https://support.microfocus.com/kb/doc.php?id=7021956).  This PR changes the check mask to allow 0x0000003d as a valid response code.

Note that other libs and clients handle this response correctly.