### PR TITLE
Fixes #309 Allows _cleanup() to close listeners on an SSHClientConnection

### DIFF
--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -2433,10 +2433,12 @@ class SSHConnection(SSHPacketHandler, asyncio.Protocol):
                                                          tunnel_connection,
                                                          listen_host,
                                                          listen_port)
-
+            
+            self._local_listeners[listen_host, listen_port] = listener
+                
             if dest_port == 0:
                 dest_port = listener.get_port()
-
+            
             return listener
         except OSError as exc:
             self.logger.debug1('Failed to create local TCP listener: %s', exc)


### PR DESCRIPTION
Allows _cleanup to close listeners on an SSHClientConnection
[Issue 309](https://github.com/ronf/asyncssh/issues/309)