### PR TITLE
Allow connection timeouts to work as expected

### DIFF
--- a/asyncssh/channel.py
+++ b/asyncssh/channel.py
@@ -302,7 +302,8 @@ class SSHChannel(SSHPacketHandler):
             if self._recv_state == 'eof_pending':
                 self._recv_state = 'eof'
 
-                if (not self._session.eof_received() and
+                if (self._session and
+                        not self._session.eof_received() and
                         self._send_state == 'open'):
                     self.write_eof()
             elif self._recv_state == 'close_pending':


### PR DESCRIPTION
While testing an asyncssh script against a known broken host that times out with openssh, I found that the timeout never occurred (following `asyncio.wait_for` advice from the documentation) and this exception was thrown immediately:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/asyncssh/connection.py", line 910, in data_received
    while self._inpbuf and self._recv_handler():
  File "/usr/local/lib/python3.8/site-packages/asyncssh/connection.py", line 1143, in _recv_packet
    processed = handler.process_packet(pkttype, seq, packet)
  File "/usr/local/lib/python3.8/site-packages/asyncssh/packet.py", line 215, in process_packet
    self._packet_handlers[pkttype](self, pkttype, pktid, packet)
  File "/usr/local/lib/python3.8/site-packages/asyncssh/channel.py", line 551, in _process_eof
    self._flush_recv_buf()
  File "/usr/local/lib/python3.8/site-packages/asyncssh/channel.py", line 305, in _flush_recv_buf
    if (not self._session.eof_received() and
AttributeError: 'NoneType' object has no attribute 'eof_received'
```

This patch prevents the exception and allows the timeout to occur.