### PR TITLE
Add client config support for HostKeyAlias

### DIFF
--- a/asyncssh/config.py
+++ b/asyncssh/config.py
@@ -481,6 +481,7 @@ class SSHClientConfig(SSHConfig):
         ('HostbasedAuthentication',         SSHConfig._set_bool),
         ('HostKeyAlgorithms',               SSHConfig._set_string),
         ('Hostname',                        _set_hostname),
+        ('HostKeyAlias',                    SSHConfig._set_string),
         ('IdentitiesOnly',                  SSHConfig._set_bool),
         ('IdentityAgent',                   SSHConfig._set_string),
         ('IdentityFile',                    SSHConfig._append_string),

--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -2553,6 +2553,7 @@ class SSHClientConnection(SSHConnection):
         self._port = options.port
 
         self._known_hosts = options.known_hosts
+        self._host_key_alias = options.host_key_alias
 
         self._server_host_key_algs = options.server_host_key_algs
         self._server_host_key = None
@@ -2634,7 +2635,8 @@ class SSHClientConnection(SSHConnection):
 
             port = self._port if self._port != DEFAULT_PORT else None
 
-            self._match_known_hosts(self._known_hosts, self._host,
+            self._match_known_hosts(self._known_hosts,
+                                    self._host_key_alias or self._host,
                                     self._peer_addr, port)
 
         default_host_key_algs = []
@@ -2704,8 +2706,9 @@ class SSHClientConnection(SSHConnection):
         """Validate and return the server's host key"""
 
         try:
-            host_key = self._validate_host_key(self._host, self._peer_addr,
-                                               self._port, key_data)
+            host_key = self._validate_host_key(
+                self._host_key_alias or self._host,
+                self._peer_addr, self._port, key_data)
         except ValueError as exc:
             raise HostKeyNotVerifiable(str(exc)) from None
 
@@ -5508,6 +5511,9 @@ class SSHClientConnectionOptions(SSHConnectionOptions):
            the keys will be looked up in the file :file:`.ssh/known_hosts`.
            If this is explicitly set to `None`, server host key validation
            will be disabled.
+       :param host_key_alias: (optional)
+           An alias to use instead of the real host name when looking up a host
+           key in known_hosts and when validating host certificates.
        :param server_host_key_algs: (optional)
            A list of server host key algorithms to use instead of the
            default of those present in known_hosts when performing the SSH
@@ -5741,6 +5747,7 @@ class SSHClientConnectionOptions(SSHConnectionOptions):
            (if present) before falling back to the default value.
        :type client_factory: `callable`
        :type known_hosts: *see* :ref:`SpecifyingKnownHosts`
+       :type host_key_alias: `str`
        :type server_host_key_algs: `str` or `list` of `str`
        :type x509_trusted_certs: *see* :ref:`SpecifyingCertificates`
        :type x509_trusted_cert_paths: `list` of `str`
@@ -5797,7 +5804,7 @@ class SSHClientConnectionOptions(SSHConnectionOptions):
                 x509_trusted_certs=(), x509_trusted_cert_paths=(),
                 x509_purposes='secureShellServer', rekey_bytes=(),
                 rekey_seconds=(), login_timeout=(), keepalive_interval=(),
-                keepalive_count_max=(), known_hosts=(),
+                keepalive_count_max=(), known_hosts=(), host_key_alias=None,
                 server_host_key_algs=(), username=(), password=None,
                 client_host_keysign=(), client_host_keys=None,
                 client_host_certs=(), client_host=None, client_username=(),
@@ -5855,6 +5862,7 @@ class SSHClientConnectionOptions(SSHConnectionOptions):
                            config.get('GlobalKnownHostsFile', [])) or ()
 
         self.known_hosts = known_hosts
+        self.host_key_alias = host_key_alias or config.get('HostKeyAlias')
 
         self.server_host_key_algs = server_host_key_algs
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1675,6 +1675,7 @@ The following OpenSSH client config options are currently supported:
   | GSSAPIKeyExchange
   | HostbasedAuthentication
   | HostKeyAlgorithms
+  | HostKeyAlias
   | Hostname
   | IdentityAgent
   | IdentityFile

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -261,6 +261,15 @@ class _TestClientConfig(_TestConfig):
         self.assertEqual(config.get('BindAddress'), 'addr')
         self.assertEqual(config.get('Port'), 2222)
 
+    def test_host_key_alias(self):
+        """Test setting HostKeyAlias"""
+
+        config = self._parse_config('Host host\n'
+                                    '  Hostname 127.0.0.1\n'
+                                    '  HostKeyAlias alias')
+
+        self.assertEqual(config.get('HostKeyAlias'), 'alias')
+
     def test_set_and_match_user(self):
         """Test setting and matching user"""
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -23,6 +23,7 @@
 import asyncio
 from copy import copy
 import os
+from pathlib import Path
 import socket
 import sys
 import unittest
@@ -1765,6 +1766,78 @@ class _TestServerWithoutCert(ServerTestCase):
         async with self.connect(known_hosts=None):
             pass
 
+
+class _TestHostKeyAlias(ServerTestCase):
+    """Unit test for HostKeyAlias, i.e., host key authentication without resolvable
+       server hostname."""
+
+    @classmethod
+    async def start_server(cls):
+        """Start an SSH server to connect to"""
+
+        skey = asyncssh.read_private_key('skey')
+        skey_cert = skey.generate_host_certificate(
+            skey, 'name', principals=['certifiedfakehost'])
+        skey_cert.write_certificate('skey-cert.pub')
+
+        return await cls.create_server(server_host_keys=[('skey', 'skey-cert.pub')])
+
+    @classmethod
+    async def asyncSetUpClass(cls):
+        """Set up keys, custom host cert, and suitable known_hosts"""
+
+        await super().asyncSetUpClass()
+
+        skey_str = Path('skey.pub').read_text()
+        Path('.ssh/known_hosts').write_text(
+            f"fakehost {skey_str}"
+            f"@cert-authority certifiedfakehost {skey_str}")
+
+        Path('.ssh/config').write_text(
+            'Host server-with-key-config\n'
+            '  Hostname 127.0.0.1\n'
+            '  HostKeyAlias fakehost\n'
+            ''
+            'Host server-with-cert-config\n'
+            '  Hostname 127.0.0.1\n'
+            '  HostKeyAlias certifiedfakehost\n')
+
+
+    def _try_connect(self, host=None, **kwargs):
+        """Try opening a connection to the server"""
+        return asyncssh.connect(host or self._server_addr, self._server_port,
+                                **kwargs)
+
+    @asynctest
+    async def test_host_key_mismatch(self):
+        """Test host key mismatch"""
+
+        with self.assertRaises(asyncssh.HostKeyNotVerifiable):
+            await self._try_connect()
+
+    @asynctest
+    async def test_host_key_match(self):
+        """Test host key match"""
+
+        await self._try_connect(host_key_alias='fakehost')
+
+    @asynctest
+    async def test_host_cert_match(self):
+        """Test host cert match"""
+
+        await self._try_connect(host_key_alias='certifiedfakehost')
+
+    @asynctest
+    async def test_host_key_match_config(self):
+        """Test host key match using HostKeyAlias in config file"""
+
+        await self._try_connect('server-with-key-config')
+
+    @asynctest
+    async def test_host_cert_match_config(self):
+        """Test host cert match using HostKeyAlias in config file"""
+
+        await self._try_connect('server-with-cert-config')
 
 class _TestServerInternalError(ServerTestCase):
     """Unit test for server internal error during auth"""


### PR DESCRIPTION
This adds support for HostKeyAlias client config option, and a
corresponding host_key_alias connection option, to support aliasing host
names in known_hosts and host certificate validation. This is modeled
after [the equivalent OpenSSH feature, as can be seen in ssh_config(5)](https://man.openbsd.org/ssh_config#HostKeyAlias).

----

Since this was a simple enough change in code, and because the functionality is already well-defined based on established usage in OpenSSH and established conventions in AsyncSSH, I chose to avoid creating a separate issue for discussing this. I think any needed discussion can happen here just as well; any required code changes can be easily carried out right here.

My personal use case for this config option is to be able to connect to servers whose IP address(es) cannot be resolved from their hostnames, without having to drop the security of host name verification or resorting to ugly hacks with per-host UserKnownHostsFile. To illustrate:

```sh
$ ping ssh-test-host
ping: ssh-test-host: Temporary failure in name resolution

$ cat <<EOF >~/.ssh/config
Host ssh-test-host
  Hostname 10.10.10.10
EOF

$ ssh ssh-test-host
The authenticity of host '10.10.10.10 (10.10.10.10)' can't be established.
ED25519 key fingerprint is ...
Are you sure you want to continue connecting (yes/no/[fingerprint])? 
```

See how the hostname (and IP address) ssh(1) uses to authenticate the server are both just the IP address? This is because ssh(1) uses the value of `Hostname` in the config as the 'host' for the purposes of authentication. This leaves us with IP-based host key checking as the only way to check host keys, which is undesirable for regular host key authentication but also renders hostname-based certificate authentication useless.

But, by setting `HostKeyAlias` to the host name that we *want* to be used for the purposes of host authentication:

```sh

$ cat <<EOF >~/.ssh/config
Host ssh-test-host
  Hostname 10.10.10.10
  HostKeyAlias ssh-test-host
EOF

$ ssh ssh-test-host
The authenticity of host 'ssh-test-host (10.10.10.10)' can't be established.
ED25519 key fingerprint is ...
Are you sure you want to continue connecting (yes/no/[fingerprint])? 
```

ssh(1) now uses a proper host name, instead of IP, for host auth.