### PR TITLE
Fixed arguments for pty_requested session callback

### DIFF
--- a/asyncssh/channel.py
+++ b/asyncssh/channel.py
@@ -1428,8 +1428,8 @@ class SSHServerChannel(SSHChannel):
             else:
                 raise ProtocolError('Invalid pty modes string')
 
-        result = self._session.pty_requested(self._term_type, self._term_size,
-                                             self._term_modes)
+        result = self._session.pty_requested(term_type, term_size,
+                                             term_modes)
 
         if result:
             self.logger.info('  PTY created')


### PR DESCRIPTION
`self._term_*` fields were passed to `pty_requested` callback before assignment. I suppose the intention was to pass the corresponding local variables.