### PR TITLE
Added a get_terminal_modes method to SSHServerChannel and SSHServerProcess

### DIFF
--- a/asyncssh/channel.py
+++ b/asyncssh/channel.py
@@ -1687,6 +1687,27 @@ class SSHServerChannel(SSHChannel):
 
         return self._term_modes.get(mode)
 
+    def get_terminal_modes(self):
+        """Return all TTY modes for this session
+
+           This method returns all the values of POSIX terminal modes
+           set by the client when the session was opened. If the client
+           didn't request a pseudo-terminal or didn't set the requested
+           TTY mode opcode, this method will return an empty dictionary.
+           Calls to this method should only be made after
+           :meth:`session_started <SSHServerSession.session_started>`
+           has been called on the :class:`SSHServerSession`. When using
+           the stream-based API, calls to this can be made at any time
+           after the handler function has started up.
+
+           :returns: A dictionary containing all the requested POSIX
+                     terminal modes or an empty dictionary if no modes
+                     were requested
+
+        """
+
+        return self._term_modes
+
     def get_x11_display(self):
         """Return the display to use for X11 forwarding
 

--- a/asyncssh/channel.py
+++ b/asyncssh/channel.py
@@ -26,6 +26,7 @@ import codecs
 import inspect
 import re
 import signal as _signal
+import types
 
 from .constants import DEFAULT_LANG, EXTENDED_DATA_STDERR
 from .constants import MSG_CHANNEL_OPEN, MSG_CHANNEL_WINDOW_ADJUST
@@ -1706,7 +1707,7 @@ class SSHServerChannel(SSHChannel):
 
         """
 
-        return self._term_modes
+        return types.MappingProxyType(self._term_modes)
 
     def get_x11_display(self):
         """Return the display to use for X11 forwarding

--- a/asyncssh/process.py
+++ b/asyncssh/process.py
@@ -1418,6 +1418,22 @@ class SSHServerProcess(SSHProcess, SSHServerStreamSession):
 
         return self._chan.get_terminal_mode(mode)
 
+    def get_terminal_modes(self):
+        """Return all TTY modes for this session
+
+           This method returns all the values of POSIX terminal modes
+           set by the client when the session was opened. If the client
+           didn't request a pseudo-terminal or didn't set the requested
+           TTY mode opcode, this method will return an empty dictionary.
+
+           :returns: A dictionary containing all the requested POSIX
+                     terminal modes or an empty dictionary if no modes
+                     were requested
+
+        """
+
+        return self._chan.get_terminal_modes()
+
     def exit(self, status):
         """Send exit status and close the channel
 

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -970,7 +970,7 @@ class _TestChannel(ServerTestCase):
             await chan.wait_closed()
 
             result = ''.join(session.recv_buf[None])
-            self.assertEqual(result, "Req: ('ansi', (80, 24, 0, 0), 9600, [(129, 9600)])\r\n")
+            self.assertEqual(result, "Req: ('ansi', (80, 24, 0, 0), 9600)\r\n")
 
     @asynctest
     async def test_terminal_full_size(self):

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -316,7 +316,8 @@ class _ChannelServer(Server):
         elif action == 'term':
             chan = stdin.channel
             info = str((chan.get_terminal_type(), chan.get_terminal_size(),
-                        chan.get_terminal_mode(asyncssh.PTY_OP_OSPEED)))
+                        chan.get_terminal_mode(asyncssh.PTY_OP_OSPEED),
+                        sorted(chan.get_terminal_modes().items())))
             stdout.write(info + '\n')
         elif action == 'xon_xoff':
             stdin.channel.set_xon_xoff(True)
@@ -934,7 +935,7 @@ class _TestChannel(ServerTestCase):
             await chan.wait_closed()
 
             result = ''.join(session.recv_buf[None])
-            self.assertEqual(result, "('ansi', (80, 24, 0, 0), 9600)\r\n")
+            self.assertEqual(result, "('ansi', (80, 24, 0, 0), 9600, [(129, 9600)])\r\n")
 
     @asynctest
     async def test_terminal_full_size(self):
@@ -951,7 +952,7 @@ class _TestChannel(ServerTestCase):
             await chan.wait_closed()
 
             result = ''.join(session.recv_buf[None])
-            self.assertEqual(result, "('ansi', (80, 24, 480, 240), 9600)\r\n")
+            self.assertEqual(result, "('ansi', (80, 24, 480, 240), 9600, [(129, 9600)])\r\n")
 
     @asynctest
     async def test_pty_without_term_type(self):
@@ -964,7 +965,7 @@ class _TestChannel(ServerTestCase):
             await chan.wait_closed()
 
             result = ''.join(session.recv_buf[None])
-            self.assertEqual(result, "('', (0, 0, 0, 0), None)\n")
+            self.assertEqual(result, "('', (0, 0, 0, 0), None, [])\n")
 
     @asynctest
     async def test_invalid_terminal_size(self):
@@ -1032,7 +1033,7 @@ class _TestChannel(ServerTestCase):
                 await chan.wait_closed()
 
                 result = ''.join(session.recv_buf[None])
-                self.assertEqual(result, "('ansi', (0, 0, 0, 0), 9600)\r\n")
+                self.assertEqual(result, "('ansi', (0, 0, 0, 0), 9600, [(129, 9600)])\r\n")
 
     @asynctest
     async def test_term_modes_incomplete(self):

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -75,7 +75,8 @@ async def _handle_client(process):
         await process.stderr.drain()
     elif action == 'term':
         info = str((process.get_terminal_type(), process.get_terminal_size(),
-                    process.get_terminal_mode(asyncssh.PTY_OP_OSPEED)))
+                    process.get_terminal_mode(asyncssh.PTY_OP_OSPEED),
+                    sorted(process.get_terminal_modes().items())))
         process.channel.set_encoding('utf-8')
         process.stdout.write(info)
     elif action == 'term_size':
@@ -222,7 +223,7 @@ class _TestProcessBasic(_TestProcess):
                                                 term_modes=modes)
             result = await process.wait()
 
-        self.assertEqual(result.stdout, "('ansi', (80, 24, 0, 0), 9600)")
+        self.assertEqual(result.stdout, "('ansi', (80, 24, 0, 0), 9600, [(129, 9600)])")
 
     @asynctest
     async def test_change_terminal_size(self):


### PR DESCRIPTION
This is to get all the modes without iterating over all the possible keys or going for nonpublic fields.