### PR TITLE
Fixed some Security Issues - Observable Discrepancy leading to an information leak in the algorithm negotiation and trivial success authentication

### DIFF
--- a/asyncssh/auth.py
+++ b/asyncssh/auth.py
@@ -132,6 +132,7 @@ class _ClientGSSKexAuth(_ClientAuth):
             self.logger.debug1('Trying GSS key exchange auth')
 
             await self.send_request(key=self._conn.get_gss_context())
+            self._conn.trivial_auth = False
         else:
             self._conn.try_next_auth()
 
@@ -184,7 +185,7 @@ class _ClientGSSMICAuth(_ClientAuth):
             token = self._gss.step()
 
             self.send_packet(MSG_USERAUTH_GSSAPI_TOKEN, String(token))
-
+            self._conn.trivial_auth = False
             if self._gss.complete:
                 self._finish()
         except GSSError as exc:
@@ -306,6 +307,7 @@ class _ClientPublicKeyAuth(_ClientAuth):
 
         self.logger.debug1('Signing request with %s key',
                            self._keypair.algorithm)
+        self._conn.trivial_auth = False
 
         await self.send_request(Boolean(True),
                                 String(self._keypair.algorithm),
@@ -381,6 +383,7 @@ class _ClientKbdIntAuth(_ClientAuth):
         num_prompts = packet.get_uint32()
         prompts = []
         for _ in range(num_prompts):
+            self._conn.trivial_auth = False
             prompt = packet.get_string()
             echo = packet.get_boolean()
 
@@ -422,7 +425,7 @@ class _ClientPasswordAuth(_ClientAuth):
             return
 
         self.logger.debug1('Trying password auth')
-
+        self._conn.trivial_auth = False
         await self.send_request(Boolean(False), String(password))
 
     async def _change_password(self, prompt, lang):

--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -169,6 +169,8 @@ _DEFAULT_MAX_PKTSIZE = 32768        # 32 kiB
 _DEFAULT_LINE_HISTORY = 1000        # 1000 lines
 _DEFAULT_MAX_LINE_LENGTH = 1024     # 1024 characters
 
+_STRICT_MODE = False
+
 
 async def _open_proxy(loop, command, conn_factory):
     """Open a tunnel running a proxy command"""
@@ -2792,6 +2794,10 @@ class SSHClientConnection(SSHConnection):
             if self._x509_trusted_certs or self._x509_trusted_cert_paths:
                 default_host_key_algs = \
                     get_default_x509_certificate_algs() + default_host_key_algs
+
+        if _STRICT_MODE:
+            default_host_key_algs = \
+                get_default_certificate_algs() + get_default_public_key_algs()
 
         self._server_host_key_algs = \
             _select_host_key_algs(

--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -667,6 +667,7 @@ class SSHConnection(SSHPacketHandler, asyncio.Protocol):
         self._auth_complete = False
         self._auth_methods = [b'none']
         self._username = None
+        self.trivial_auth = True
 
         self._channels = {}
         self._next_recv_chan = 0
@@ -2011,7 +2012,9 @@ class SSHConnection(SSHPacketHandler, asyncio.Protocol):
 
     def _process_userauth_success(self, _pkttype, pktid, packet):
         """Process a user authentication success response"""
-
+        if _STRICT_MODE and self.trivial_auth:
+            self._force_close(PermissionDenied('trivial auth'))
+            return
         packet.check_end()
 
         if self.is_client() and self._auth:


### PR DESCRIPTION
AsyncSSH has an Observable Discrepancy leading to an information leak in the algorithm negotiation. This allows man-in-the-middle attackers to target initial connection attempts (where no host key for the server has been cached by the client). 

This vulnerability allows a man in the middle attack to determine, if a client already has prior knowledge of the remote hosts fingerprint.

Using this information leak it is possible to ignore clients, which will show an error message during an man in the middle attack, while new clients can be intercepted without alerting them of the man in the middle attack.

This is the same vulnerability like in [OpenSSH](https://docs.ssh-mitm.at/CVE-2020-14145.html) and [PuTTY](https://docs.ssh-mitm.at/CVE-2020-14002.html).

This pull request introduces a new flag, which enables a strict security mode. With this mode enabled, some common mitm attacks are harder to achieve.

Client example:

```python
import asyncio, asyncssh, sys

asyncssh.connection._STRICT_MODE = True

async def run_client():
    async with asyncssh.connect('localhost' , port=10022) as conn:
        result = await conn.run('ls', check=True)
        print(result.stdout, end='')

try:
    asyncio.get_event_loop().run_until_complete(run_client())
except (OSError, asyncssh.Error) as exc:
    sys.exit('SSH connection failed: ' + str(exc))
```

Example known host fingerprint:

```
['rsa-sha2-256', 'rsa-sha2-512', 'ssh-rsa-sha224@ssh.com', 'ssh-rsa-sha256@ssh.com', 'ssh-rsa-sha384@ssh.com', 'ssh-rsa-sha512@ssh.com', 'ssh-rsa']
```

Without known fingerprint or with `asyncssh.connection._STRICT_MODE = True`

```
['sk-ssh-ed25519-cert-v01@openssh.com', 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com', 'ssh-ed25519-cert-v01@openssh.com', 'ssh-ed448-cert-v01@openssh.com', 'ecdsa-sha2-nistp521-cert-v01@openssh.com', 'ecdsa-sha2-nistp384-cert-v01@openssh.com', 'ecdsa-sha2-nistp256-cert-v01@openssh.com', 'ecdsa-sha2-1.3.132.0.10-cert-v01@openssh.com', 'ssh-rsa-cert-v01@openssh.com', 'sk-ssh-ed25519@openssh.com', 'sk-ecdsa-sha2-nistp256@openssh.com', 'ssh-ed25519', 'ssh-ed448', 'ecdsa-sha2-nistp521', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-1.3.132.0.10', 'rsa-sha2-256', 'rsa-sha2-512', 'ssh-rsa-sha224@ssh.com', 'ssh-rsa-sha256@ssh.com', 'ssh-rsa-sha384@ssh.com', 'ssh-rsa-sha512@ssh.com', 'ssh-rsa']
```

If strict mode is enabled, the default algorithm list will be sent to the server and a mitm attacker does not know, if this is the first connection attempt or if strict mode is enabled.

If a mitm server wants to intercept the connection and the server fingerprint is known, asyncssh will close the session because of different fingerprints.

If strict mode is not enabled and the server detects, that the client allready knows the fingerprint, the mitm server can pass the connection to the destination server. With this method, a mitm server avoids raising errors due to invalid host fingerprints.
