### PR TITLE
Use funtools.partial instead of global in remote forwarding example

### DIFF
--- a/examples/remote_forwarding_client2.py
+++ b/examples/remote_forwarding_client2.py
@@ -21,9 +21,9 @@
 #     Ron Frederick - initial implementation, API, and documentation
 
 import asyncio, asyncssh, sys
+from functools import partial
 
-def connection_requested(orig_host, orig_port):
-    global conn
+def connection_requested(conn, orig_host, orig_port):
 
     if orig_host in ('127.0.0.1', '::1'):
         return conn.forward_connection('localhost', 80)
@@ -33,10 +33,10 @@ def connection_requested(orig_host, orig_port):
             'Connections only allowed from localhost')
 
 async def run_client():
-    global conn
 
     async with asyncssh.connect('localhost') as conn:
-        listener = await conn.create_server(connection_requested, '', 8080)
+        listener = await conn.create_server(
+            partial(connection_requested, conn), '', 8080)
         await listener.wait_closed()
 
 try:


### PR DESCRIPTION

This is kind of nitpicking but usage funtools.partial is more in spirit with asyncio documentation.