### PR TITLE
tests: print failed commands

### DIFF
--- a/tests/util.py
+++ b/tests/util.py
@@ -192,6 +192,7 @@ def run(cmd):
         return subprocess.check_output(cmd, shell=True,
                                        stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as exc: # pragma: no cover
+        print('command failed: %s' % cmd)
         print(exc.output.decode())
         raise
 


### PR DESCRIPTION
Show the exact command that failed, so that developers can reproduce and debug failing commands more easily.

For example, this makes it easier to understand when tests run `openssl` commands with unsupported options.