### PR TITLE
Increase minimum required fido2 version to 0.9.2

### DIFF
--- a/asyncssh/sk.py
+++ b/asyncssh/sk.py
@@ -167,7 +167,7 @@ def sk_enroll(alg: int, application: bytes, user: str,
     try:
         return _ctap2_enroll(dev, alg, application, user, pin, resident)
     except CtapError as exc:
-        if exc.code == CtapError.ERR.PIN_REQUIRED:
+        if exc.code == CtapError.ERR.PUAT_REQUIRED:
             raise ValueError('PIN required') from None
         elif exc.code == CtapError.ERR.PIN_INVALID:
             raise ValueError('Invalid PIN') from None

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(name = 'asyncssh',
       install_requires = ['cryptography >= 2.8', 'typing_extensions >= 3.6'],
       extras_require = {
           'bcrypt':     ['bcrypt >= 3.1.3'],
-          'fido2':      ['fido2 == 0.9.1'],
+          'fido2':      ['fido2 >= 0.9.2'],
           'gssapi':     ['gssapi >= 1.2.0'],
           'libnacl':    ['libnacl >= 1.4.2'],
           'pkcs11':     ['python-pkcs11 >= 0.7.0'],

--- a/tests/sk_stub.py
+++ b/tests/sk_stub.py
@@ -195,7 +195,7 @@ class Ctap2(_CtapStub):
         if self.dev.error == 'err':
             raise CtapError(CtapError.ERR.INVALID_CREDENTIAL)
         elif self.dev.error == 'pinreq':
-            raise CtapError(CtapError.ERR.PIN_REQUIRED)
+            raise CtapError(CtapError.ERR.PUAT_REQUIRED)
         elif self.dev.error == 'badpin':
             raise CtapError(CtapError.ERR.PIN_INVALID)
 


### PR DESCRIPTION
Related fido2 change: https://github.com/Yubico/python-fido2/commit/e9e56457d7f35cd3338e67573e6c43dc742b4b41