### PR TITLE
Use pytest and friends in tox

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,5 +9,6 @@ exclude_lines =
 partial_branches =
     pragma: no branch
     for .*
-omit =
-    .tox/*
+include =
+    asyncssh/*
+    tests/*

--- a/asyncssh/config.py
+++ b/asyncssh/config.py
@@ -477,7 +477,7 @@ class SSHClientConfig(SSHConfig):
         conn_hash = sha1(conn_info.encode('utf-8')).hexdigest()
 
         self._tokens.update({'C': conn_hash,
-                             'd': str(Path.home()),
+                             'd': str(os.path.expanduser('~')),
                              'h': host,
                              'L': short_local_host,
                              'l': local_host,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -357,13 +357,13 @@ class _TestClientConfig(_TestConfig):
 
             return 'thishost.local'
 
-        def mock_home():
+        def mock_expanduser(_):
             """Return a static local home directory"""
 
             return '/home/user'
 
         with patch('socket.gethostname', mock_gethostname):
-            with patch('pathlib.Path.home', mock_home):
+            with patch('os.path.expanduser', mock_expanduser):
                 config = self._parse_config(
                     'Hostname newhost\n'
                     'User newuser\n'

--- a/tests/test_public_key.py
+++ b/tests/test_public_key.py
@@ -71,6 +71,11 @@ except subprocess.CalledProcessError: # pragma: no cover
 
 _openssl_available = _openssl_version != b''
 
+if _openssl_available:
+    _openssl_curves = run('openssl ecparam -list_curves')
+else:
+    _openssl_curves = b''
+
 # The openssl "-v2prf" option is only available in OpenSSL 1.0.2 or later
 _openssl_supports_v2prf = _openssl_version >= b'OpenSSL 1.0.2'
 
@@ -2260,9 +2265,9 @@ class _TestPublicKeyTopLevel(TempDirTestCase):
                         '-param_enc explicit' % curve)
                     asyncssh.read_private_key('priv')
 
-    @unittest.skipIf(b'secp224r1' not in run('openssl ecparam -list_curves'),
-                     "this openssl doesn't support secp224r1")
     @unittest.skipIf(not _openssl_available, "openssl isn't available")
+    @unittest.skipIf(b'secp224r1' not in _openssl_curves,
+                     "this openssl doesn't support secp224r1")
     def test_ec_explicit_unknown(self):
         """Import EC key with unknown explicit parameters"""
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,48 @@
 [tox]
-envlist = {py36,py37,py38,py39,py310}-{linux,macos,windows}
+minversion = 3.7
+envlist = clean,{py36,py37,py38,py39,py310}-{linux,darwin,windows},report
+skip_missing_interpreters = True
 
 [testenv]
 deps =
+    aiofiles>=0.6.0
     bcrypt>=3.1.3
-    coverage
-    linux,macos: gssapi>=1.2.0
+    fido2>=0.9.2
     libnacl>=1.4.2
     pyOpenSSL>=17.0.0
-    python-pkcs11>=0.7.0
+    pytest>=7.0.1
+    pytest-cov>=3.0.0
     setuptools>=18.5
+    linux,darwin: gssapi>=1.2.0
+    linux,darwin: python-pkcs11>=0.7.0
+    linux,darwin: uvloop>=0.9.1
     windows: pywin32>=227
-    {py36,py37,py38,py39,py310}-{linux,macos}: uvloop>=0.9.1
 platform =
     linux: linux
-    macos: darwin
+    darwin: darwin
     windows: win32
-sitepackages = True
-skip_missing_interpreters = True
 usedevelop = True
+setenv =
+    {py36,py37,py38,py39,py310}-{linux,darwin,windows}: COVERAGE_FILE = .coverage.{envname}
 commands =
-    {envpython} -m coverage run -p -m unittest
+    {envpython} -m pytest --cov --cov-report=term-missing:skip-covered {posargs}
+depends =
+    {py36,py37,py38,py39,py310}-{linux,darwin,windows}: clean
+    report: {py36,py37,py38,py39,py310}-{linux,darwin,windows}
+
+[testenv:clean]
+deps = coverage
+skip_install = true
+commands = coverage erase
+
+[testenv:report]
+deps = coverage
+skip_install = true
+parallel_show_output = true
+commands =
+    coverage combine
+    coverage report --show-missing
+    coverage html
+
+[pytest]
+testpaths = tests


### PR DESCRIPTION
This PR makes tests run by tox use PyTest. PyTest is compatible with unittest-style tests, offers better output, and has a great ecosystem with many plugins.

Some comments:
- The purpose of `clean` and `report` envs is documented at https://pytest-cov.readthedocs.io/en/latest/tox.html.
- Platform names are changed to align with `platform.system()`.
- The `skip_missing_interpreters` option belongs to `[tox]`, otherwise it does not work.
- `deps` is updated with all optional deps.
  - `pytest-cov` is for coverage collection and reporting.
  - `pytest-xdist` is for running tests in parallel. On my machine, the total time taken to run a single round of test is reduced from ~6 minutes to ~2 minutes.
  - `python-pkcs11` currently does not install on Windows, due to danni/python-pkcs11#133. It is thus excluded for now.

If desired I can also make a PR to run tests on GH actions. Here is an example, it should take ~20 minutes: https://github.com/hexchain/asyncssh/actions/runs/1814008759

Note that on Windows and Python 3.8+, a lot of tests hang indefinitely so these combinations are excluded.