### PR TITLE
Integrate with GitHub actions and codecov.io

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,9 @@
 [run]
 branch = True
+relative_files = True
+source =
+    asyncssh
+    tests
 
 [report]
 exclude_lines =
@@ -9,6 +13,3 @@ exclude_lines =
 partial_branches =
     pragma: no branch
     for .*
-include =
-    asyncssh/*
-    tests/*

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,104 @@
+name: Run tests
+on: [push, pull_request]
+
+jobs:
+  run-tests:
+    name: Run tests
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        openssl-version: ["default"]
+        include:
+          - os: macos-latest
+            python-version: "3.10"
+            openssl-version: "3"
+        exclude:
+          # test hangs on these combination
+          - os: windows-latest
+            python-version: "3.8"
+          - os: windows-latest
+            python-version: "3.9"
+          - os: windows-latest
+            python-version: "3.10"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Determine pip cache path
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+      - name: Set up pip cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: pip-${{ runner.os }}-${{ hashFiles('setup.py', 'tox.ini') }}
+          restore-keys: |
+            pip-${{ runner.os }}-
+      - name: Determine vcpkg cache path
+        if: ${{ runner.os == 'Windows' }}
+        id: vcpkg-cache
+        run: |
+          echo "::set-output name=archives-dir::$env:LOCALAPPDATA\vcpkg\archives"
+          echo "::set-output name=downloads-dir::$env:VCPKG_INSTALLATION_ROOT\downloads"
+      - name: Set up vcpkg cache
+        uses: actions/cache@v2
+        if: ${{ runner.os == 'Windows' }}
+        with:
+          path: |
+            ${{ steps.vcpkg-cache.outputs.archives-dir }}
+            ${{ steps.vcpkg-cache.outputs.downloads-dir }}
+          key: vcpkg
+      - name: Install Linux dependencies
+        if: ${{ runner.os == 'Linux' }}
+        run: sudo apt install -y --no-install-recommends libnettle7 libsodium-dev libssl-dev libkrb5-dev ssh
+      - name: Install macOS dependencies
+        if: ${{ runner.os == 'macOS' }}
+        run: brew install nettle libsodium openssl
+      - name: Provide OpenSSL 3
+        if: ${{ matrix.openssl-version == '3' }}
+        run: echo "/usr/local/opt/openssl@3/bin" >> $GITHUB_PATH
+      - name: Install Windows dependencies
+        if: ${{ runner.os == 'Windows' }}
+        run: vcpkg install libsodium nettle openssl --triplet x64-windows
+      - name: Install Python dependencies
+        run: pip install tox
+      - name: Run tests
+        shell: python
+        run: |
+          import os, sys, platform
+          V = sys.version_info
+          p = platform.system().lower()
+          exit(os.system(f"tox -e py{V.major}{V.minor}-{p} -- -ra"))
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage
+          path: .coverage.*
+          retention-days: 1
+  report-coverage:
+    name: Report coverage
+    runs-on: ubuntu-latest
+    needs: run-tests
+    if: ${{ always() }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: coverage
+      - name: Install dependencies
+        run: |
+          sudo apt install -y sqlite3
+          pip install tox
+      - name: Report coverage
+        run: |
+          shopt -s nullglob
+          for f in .coverage.*-windows; do
+            sqlite3 "$f" "update file set path = replace(path, '\\', '/');"
+          done
+          tox -e report

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,7 +9,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
-        openssl-version: ["default"]
         include:
           - os: macos-latest
             python-version: "3.10"
@@ -60,7 +59,7 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         run: brew install nettle libsodium openssl
       - name: Provide OpenSSL 3
-        if: ${{ matrix.openssl-version == '3' }}
+        if: ${{ runner.os == 'macOS' && matrix.openssl-version == '3' }}
         run: echo "/usr/local/opt/openssl@3/bin" >> $GITHUB_PATH
       - name: Install Windows dependencies
         if: ${{ runner.os == 'Windows' }}
@@ -102,3 +101,6 @@ jobs:
             sqlite3 "$f" "update file set path = replace(path, '\\', '/');"
           done
           tox -e report
+      - uses: codecov/codecov-action@v2
+        with:
+          files: coverage.xml

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,7 @@ commands =
     coverage combine
     coverage report --show-missing
     coverage html
+    coverage xml
 
 [pytest]
 testpaths = tests


### PR DESCRIPTION
This PR adds a GitHub actions workflow that runs the testsuite in all possible environments, compute the combined coverage, and (optionally) upload the coverage report to codecov.io.

Example workflow execution: https://github.com/hexchain/asyncssh/actions/runs/1871956917
Example codecov report: https://codecov.io/gh/hexchain/asyncssh/tree/90609cd4f3b98fe1f747c8cf6d63c90d6de1eae5