### PR TITLE
Account for size of payload length when sending data

### DIFF
--- a/asyncssh/channel.py
+++ b/asyncssh/channel.py
@@ -294,8 +294,13 @@ class SSHChannel(Generic[AnyStr], SSHPacketHandler):
         """Flush as much data in send buffer as the send window allows"""
 
         while self._send_buf and self._send_window:
-            pktsize = min(self._send_window, self._send_pktsize)
             buf, datatype = self._send_buf[0]
+            pktsize = min(self._send_window, self._send_pktsize)
+            pktsize -= 4  # 4-byte payload length
+            self.logger.debug2('Adjusted packet size from min(%d, %d) to %d',
+                               self._send_window, self._send_pktsize, pktsize)
+            if pktsize <= 0:
+                break
 
             if len(buf) > pktsize:
                 data = buf[:pktsize]


### PR DESCRIPTION
At least dropbear negotiates a precise packet size limit which must not
be exceeded by the sender, and that limit excludes only the 1-byte
packet type, 4-byte channel, and 4-byte data type (for
MSG_CHANNEL_EXTENDED_DATA). Thus, it includes in particular the 4-byte
payload length, which must also fit into the limit.

If the send window is exhausted the subtraction can cause the resulting
packet size to reach zero, which must also be handled to avoid sending
empty data packets.

Without this change, buffering more data than the negotiated packet size
will result in the sent packets triggering "bad packet, oversized
decompressed" errors from dropbear.

Fixes #459.

---

Especially having to do that `pktsize <= 0` check makes me feel like this probably isn't the appropriate fix, but at least I've tested that this works and I don't really have any alternative ideas.

To demonstrate that it's required at least in the context of this change, using e.g. a 100000-length payload in the test case in #459 shows the zero case triggering several times:

```
INFO:asyncssh:[conn=0, chan=0] Requesting new SSH session
DEBUG:asyncssh:[conn=0, chan=0]   Initial recv window 2097152, packet size 32768
DEBUG:asyncssh:[conn=0, chan=0]   Initial send window 65536, packet size 32759
INFO:asyncssh:[conn=0, chan=0]   Command: cat
DEBUG:asyncssh:[conn=0, chan=0] Sending 100000 data bytes
DEBUG:asyncssh:[conn=0, chan=0] Adjusted packet size from min(65536, 32759) to 32755
DEBUG:asyncssh:[conn=0, chan=0] Adjusted packet size from min(32781, 32759) to 32755
DEBUG:asyncssh:[conn=0, chan=0] Adjusted packet size from min(26, 32759) to 22
DEBUG:asyncssh:[conn=0, chan=0] Adjusted packet size from min(4, 32759) to 0
DEBUG:asyncssh:[conn=0, chan=0] Sending EOF
DEBUG:asyncssh:[conn=0, chan=0] Adjusted packet size from min(4, 32759) to 0
DEBUG:asyncssh:[conn=0, chan=0] Reading from channel started
DEBUG:asyncssh:[conn=0, chan=0] Received window adjust of 32755 bytes, new window 32759
DEBUG:asyncssh:[conn=0, chan=0] Adjusted packet size from min(32759, 32759) to 32755
DEBUG:asyncssh:[conn=0, chan=0] Adjusted packet size from min(4, 32759) to 0
DEBUG:asyncssh:[conn=0, chan=0] Received window adjust of 32755 bytes, new window 32759
DEBUG:asyncssh:[conn=0, chan=0] Adjusted packet size from min(32759, 32759) to 32755
DEBUG:asyncssh:[conn=0, chan=0] Received window adjust of 34490 bytes, new window 65536
DEBUG:asyncssh:[conn=0, chan=0] Received 16375 data bytes
DEBUG:asyncssh:[conn=0, chan=0] Received 16375 data bytes
DEBUG:asyncssh:[conn=0, chan=0] Received 16375 data bytes
DEBUG:asyncssh:[conn=0, chan=0] Received 16375 data bytes
DEBUG:asyncssh:[conn=0, chan=0] Received 19 data bytes
DEBUG:asyncssh:[conn=0, chan=0] Received 16375 data bytes
DEBUG:asyncssh:[conn=0, chan=0] Received 16375 data bytes
DEBUG:asyncssh:[conn=0, chan=0] Received 1731 data bytes
DEBUG:asyncssh:[conn=0, chan=0] Received EOF
INFO:asyncssh:[conn=0, chan=0] Received exit status 0
```