### PR TITLE
Reintroduce backend arg to cipher.

### DIFF
--- a/asyncssh/crypto/chacha.py
+++ b/asyncssh/crypto/chacha.py
@@ -42,7 +42,7 @@ if backend.poly1305_supported():
         """Encrypt/decrypt a block of data with the ChaCha20 cipher"""
 
         return Cipher(ChaCha20(key, (_CTR_1 if ctr else _CTR_0) + nonce),
-                      mode=None).encryptor().update(data)
+                      mode=None, backend=backend).encryptor().update(data)
 
     def poly1305_key(key: bytes, nonce: bytes) -> bytes:
         """Derive a Poly1305 key"""


### PR DESCRIPTION
I believe an incorrect change was made here asyncssh/crypto/chacha.py where a "backend" was removed and no longer passed into Cypher. The commit hash that includes the change is 88dcdac875e186bcd47b9c15f66b2935317033c6. The commit message mentions adding in TypeDefs so removing the arg was likely a mistake with the current minimum recommended version of cryptography==2.8. The change breaks the code path, however it is clear that future cryptograph versions intended to deprecate the backend arg, so the thing to do might be to unpin/update the minimum cryptography version.