### PR TITLE
sftp: try all parents in makedirs before raising permissions error

### DIFF
--- a/asyncssh/sftp.py
+++ b/asyncssh/sftp.py
@@ -4038,7 +4038,8 @@ class SFTPClient:
         curpath = b'/' if posixpath.isabs(path) else (self._cwd or b'')
         exists = True
 
-        for part in path.split(b'/'):
+        parts = path.split(b'/')
+        for i, part in enumerate(parts):
             curpath = posixpath.join(curpath, part)
 
             try:
@@ -4054,6 +4055,10 @@ class SFTPClient:
                         else SFTPFailure
 
                     raise exc('%s is not a directory' % curpath_str) from None
+            except SFTPPermissionDenied:
+                if i == len(parts) - 1:
+                    raise
+                continue
 
         if exists and not exist_ok:
             exc = SFTPFileAlreadyExists if self.version >= 6 else SFTPFailure


### PR DESCRIPTION
`sftp.makedirs` currently iterates over all parent directories in the given path (to run `mkdir` on each parent), but in certain configurations users not may have permissions to run `mkdir` in each parent (particularly when `makedirs()` is called with an abspath, since that leads to a `mkdir('/')` call).

So you can have a scenario where the directory `/foo` exists on the server and then want to call `sftp.makedirs('/foo/bar/baz')`. The user may have the correct permissions to run `mkdir('/foo/bar')` and `mkdir('/foo/bar/baz')` over SFTP, but not `mkdir('/')` and `mkdir('/foo')`. This currently leads to an `SFTPPermissionDenied` exception in asyncssh, since the very first `mkdir('/')` call will fail with the permissions error (and not with a `/` dir already exists error).

This PR changes the behavior so that if `makedirs` encounters an `SFTPPermissionDenied` error when trying to create the parent directories, it will still continue trying each subsequent parent, and only re-raise the permission error if it fails to create the full set of parent dirs.

see specific examples in: https://github.com/fsspec/sshfs/issues/21 https://github.com/iterative/dvc/issues/7174