### PR TITLE
add 'pattern' attribute to SFTPGlob.match() exception

### DIFF
--- a/asyncssh/sftp.py
+++ b/asyncssh/sftp.py
@@ -2152,6 +2152,7 @@ class SFTPGlob:
                 self._report_match(path, attrs)
         except (OSError, SFTPError) as exc:
             setattr(exc, 'srcpath', path)
+            setattr(exc, 'pattern', pattern)
 
             if error_handler:
                 error_handler(exc)


### PR DESCRIPTION
Allow new `SFTPGlob.match()` to return pattern value when raising `OSError` or `SFTPError` exceptions. This would allow to define which pattern is returning 'No matches found' error when using more than one patterns in `SFTPClient.glob()` and `SFTPClient.glob_sftpname()` methods.

Please note, in previous implementation `SFTPClient.glob()` was returning pattern value in 'srcpath' attribute which is now returning plain path portion of a pattern.

Proposed solution here is to (simply) add new 'pattern' attribute to exception.