### PR TITLE
Close send channel on channel close

### DIFF
--- a/asyncssh/channel.py
+++ b/asyncssh/channel.py
@@ -233,7 +233,7 @@ class SSHChannel(Generic[AnyStr], SSHPacketHandler):
 
             assert self._recv_chan is not None
             self._conn.remove_channel(self._recv_chan)
-            self._send_chan = None
+            self._close_send()
             self._recv_chan = None
             self._conn = None
 


### PR DESCRIPTION
### Short Description
After the client closed the connection, the calls to `stdout.write` should be interrupted with `BrokenPipeError`, so the `_send_state` should be set to `closed`.

### Long Description

Run the server in *Server Examples > Line Editing*
https://asyncssh.readthedocs.io/en/stable/#line-editing

Connect with a ssh-client, and close the connection (e.g with `\n~.`) while the server is wait for input. The `handle_client` coroutine  continues to handle stdin/stdout streams and exits without any Exception (without noticing of a closed connection).