### PR TITLE
Guard win32 imports on non-win32 systems

### DIFF
--- a/tests/sspi_stub.py
+++ b/tests/sspi_stub.py
@@ -21,8 +21,12 @@
 
 """Stub SSPI module for unit tests"""
 
-from asyncssh.gss_win32 import ASC_RET_INTEGRITY, ISC_RET_INTEGRITY
-from asyncssh.gss_win32 import SECPKG_ATTR_NATIVE_NAMES, SSPIError
+
+import sys
+
+if sys.platform == 'win32': # pragma: no cover
+    from asyncssh.gss_win32 import ASC_RET_INTEGRITY, ISC_RET_INTEGRITY
+    from asyncssh.gss_win32 import SECPKG_ATTR_NATIVE_NAMES, SSPIError
 
 from .gss_stub import step
 


### PR DESCRIPTION
This fixes a unit test case error on Fedora Rawhide.

See also: https://kojipkgs.fedoraproject.org//work/tasks/5653/89275653/build.log

It's basically a roll-back of: https://github.com/ronf/asyncssh/commit/a89241a778b09e117cd5673acbd3d7bc38b90468

Perhaps I'm missing something - but I don't think that (even if one would install the sspi win32 wrapper package under Linux) this could increase the coverage under Linux because the stub usage is also guarded:

https://github.com/ronf/asyncssh/blob/161ba01bcc5f7fa207e12c9b85adb5d1dd9ffc66/tests/util.py#L120-L125