### PR TITLE
Also patch pathlib expanduser

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -417,8 +417,12 @@ class _TestClientConfig(_TestConfig):
 
             return path
 
+        def mock_pathlib_expanduser(s):
+            return s._from_parts([os.environ['HOME']] + s._parts[1:])
+
         with self.assertRaises(asyncssh.ConfigParseError):
-            with patch('os.path.expanduser', mock_expanduser):
+            with patch('os.path.expanduser', mock_expanduser), \
+                    patch('pathlib.Path.expanduser', mock_pathlib_expanduser):
                 self._parse_config('RemoteCommand %d')
 
     def test_uid_percent_expansion_unavailable(self):


### PR DESCRIPTION
NB: with recent Python versions the existing `os.path.expanduser()` patch
also affects `pathlib.path.expanduser()` which is invoked by the config
parser for expanding `~/.ssh`.

---

See also:

https://github.com/python/cpython/blob/0fc8ac0b0db6c03182c5181475c7b0b2ff7ec11f/Lib/pathlib.py#L1307-L1318

https://github.com/ronf/asyncssh/blob/161ba01bcc5f7fa207e12c9b85adb5d1dd9ffc66/asyncssh/config.py#L69

https://kojipkgs.fedoraproject.org//work/tasks/7315/89277315/build.log