### PR TITLE
Fixed endless read with exact=True.

### DIFF
--- a/asyncssh/stream.py
+++ b/asyncssh/stream.py
@@ -511,10 +511,12 @@ class SSHStreamSession(Generic[AnyStr]):
         data: List[AnyStr] = []
 
         async with self._read_locks[datatype]:
+            break_read = False
             while True:
                 while recv_buf and n != 0:
                     if isinstance(recv_buf[0], Exception):
                         if data:
+                            break_read = True
                             break
                         else:
                             exc = cast(Exception, recv_buf.pop(0))
@@ -542,7 +544,7 @@ class SSHStreamSession(Generic[AnyStr]):
                     continue
 
                 if n == 0 or (n > 0 and data and not exact) or \
-                        (n < 0 and recv_buf) or self._eof_received:
+                        (n < 0 and recv_buf) or self._eof_received or break_read:
                     break
 
                 await self._block_read(datatype)


### PR DESCRIPTION
Assume that read called as read(10, None, True).
Assume that 5 bytes is already read and TerminalSizeChanged raised. After checking that recv_buf[0] is instance of Exception and some data is received we should break **outer** while loop to get IncompleteReadError raised.

P.S.
I'm sorry I don't understand how to indicate that I OK with EPL 2.0 before pull request.
So I'm OK with EPL 2.0 :)