### PR TITLE
config: fix _set_string list with 'none' values

### DIFF
--- a/asyncssh/config.py
+++ b/asyncssh/config.py
@@ -243,7 +243,10 @@ class SSHConfig:
         """Set whitespace-separated string config options as a list"""
 
         if option not in self._options:
-            self._options[option] = args[:]
+            if len(args) == 1 and args[0].lower() == 'none':
+                self._options[option] = []
+            else:
+                self._options[option] = args[:]
 
         args.clear()
 
@@ -292,6 +295,7 @@ class SSHConfig:
 
         if option not in self._options:
             self._options[option] = byte_limit, time_limit
+
 
     def parse(self, path: Path) -> None:
         """Parse an OpenSSH config file and return matching declarations"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -279,6 +279,10 @@ class _TestClientConfig(_TestConfig):
                                     'UserKnownHostsFile file2')
         self.assertEqual(config.get('UserKnownHostsFile'), ['file1'])
 
+        config = self._parse_config('UserKnownHostsFile none\n'
+                                    'UserKnownHostsFile file2')
+        self.assertEqual(config.get('UserKnownHostsFile'), [])
+
     def test_append_string_list(self):
         """Test appending multiple string config options to a list"""
 


### PR DESCRIPTION
This makes asyncssh behave like OpenSSH for config options set to `none` which are interpreted as string lists (such as `ProxyCommand`, `GlobalKnownHostsFile`, `UserKnownHostsFile` and `ProxyJump`)

fixes #528

