### PR TITLE
Link to PyPI and documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,12 @@
+.. image:: https://readthedocs.org/projects/asyncssh/badge/?version=latest
+    :target: https://asyncssh.readthedocs.io/en/latest/?badge=latest
+    :alt: Documentation Status
+
+.. image:: https://img.shields.io/pypi/v/asyncssh.svg
+    :target: https://pypi.python.org/pypi/asyncssh/
+    :alt: AsyncSSH PyPI Project
+
+
 AsyncSSH: Asynchronous SSH for Python
 =====================================
 


### PR DESCRIPTION
Link prominently to the PyPI and documentation packages from the README.

The PyPI link is important to establish as clear as possible what the official PyPI project name is. For example, for new users who are quick to pip install it, they can then simply follow that link and copy and paste the PyPI name to avoid typos on the command line (to protect against typosquatting). Also there are projects where github reponame is unequal to the PyPI name, thus, such a link clears it up.

Having the documentation link placed on top helps to getting started, clarifies that this package indeed has an extensive documentation and is the most likely and fastest way to the changelog.