### PR TITLE
Read from stdout instead of communicate

### DIFF
--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -902,7 +902,7 @@ class _TestProcessRedirection(_TestProcess):
             proc1.stdin.write(data)
             proc1.stdin.write_eof()
 
-            stdout_data, _ = await proc2.communicate()
+            stdout_data = await proc2.stdout.read()
 
         self.assertEqual(stdout_data, data.encode('ascii'))
 


### PR DESCRIPTION
This fixes the failure of the test_stdout_stream case when running under Python 3.12 (beta), on Fedora Rawhide (i.e. pre-F39).

When using communicate() there is a race where stdin is closed too early.

---


Failure log:  https://kojipkgs.fedoraproject.org//work/tasks/9302/103229302/build.log

```
======================================================================
FAIL: test_stdout_stream (tests.test_process._TestProcessRedirection.test_stdout_stream)
Test with stdout redirected to an asyncio stream
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/builddir/build/BUILD/asyncssh-2.13.2/tests/util.py", line 97, in async_wrapper
    return self.loop.run_until_complete(coro(self, *args, **kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/base_events.py", line 664, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/builddir/build/BUILD/asyncssh-2.13.2/tests/test_process.py", line 907, in test_stdout_stream
    self.assertEqual(stdout_data, data.encode('ascii'))
AssertionError: b'' != b'4121131720'
----------------------------------------------------------------------
Ran 1504 tests in 2216.356s
FAILED (failures=1, skipped=53)
```

Success log (with the fix):  https://kojipkgs.fedoraproject.org//work/tasks/3111/103233111/build.log

```
test_stdout_stream (tests.test_process._TestProcessRedirection.test_stdout_stream)
Test with stdout redirected to an asyncio stream ... ok
[..]
Ran 1504 tests in 713.627s
OK (skipped=53)
```

