### PR TITLE
Make log show what user and host the error happened.

### DIFF
--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -3286,9 +3286,9 @@ class SSHClientConnection(SSHConnection):
             if self._auth:
                 return
 
-        self.logger.info('Auth failed for user %s', self._username)
+        self.logger.info('Auth failed for %s@%s' % (self._username, self._host))
 
-        self._force_close(PermissionDenied('Permission denied'))
+        self._force_close(PermissionDenied('Permission denied for %s@%s' % (self._username, self._host)))
 
     def gss_kex_auth_requested(self) -> bool:
         """Return whether to allow GSS key exchange authentication or not"""


### PR DESCRIPTION
Because we are running ssh to many hosts, the existing error is missing host information the permission error happened on.

It would be beneficial for that to exist in the exception and on one line of the log.  

The exception that is caught:  
`Permission denied for pete@builder1`

And log:
```
2023-07-16 07:48:04,989 asyncssh logging log line 92 INFO : [conn=0] Auth failed for pete@builder1
2023-07-16 07:48:04,990 asyncssh logging log line 92 INFO : [conn=0] Connection failure: Permission denied for pete@builder1
```

Kind Regards
Pete