### PR TITLE
Enable --use-pep517 for tox-invoked pip

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -111,7 +111,7 @@ jobs:
           V = sys.version_info
           p = platform.system().lower()
           subprocess.run(
-              ['tox', '-e', f'py{V.major}{V.minor}-{p}', '--', '-ra'],
+              ['tox', 'run', '-e', f'py{V.major}{V.minor}-{p}', '--', '-ra'],
               check=True)
 
       - name: Upload coverage data

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ platform =
     windows: win32
 usedevelop = True
 setenv =
+    PIP_USE_PEP517 = 1
     COVERAGE_FILE = .coverage.{envname}
 commands =
     {envpython} -m pytest --cov --cov-report=term-missing:skip-covered {posargs}


### PR DESCRIPTION
Seems this is now required to make Cython (required by python-pkcs11) happy.

Closes #583.