### PR TITLE
Use Self TypeVar for SSHConnection __aenter__

### DIFF
--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -179,7 +179,7 @@ _ServerFactory = Callable[[], SSHServer]
 _ProtocolFactory = Union[_ClientFactory, _ServerFactory]
 
 _Conn = TypeVar('_Conn', 'SSHClientConnection', 'SSHServerConnection')
-_ConnSelf = TypeVar("_ConnSelf", bound="SSHConnection")
+_ConnSelf = TypeVar('_ConnSelf', bound='SSHConnection')
 
 class _TunnelProtocol(Protocol):
     """Base protocol for connections to tunnel SSH over"""

--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -179,6 +179,7 @@ _ServerFactory = Callable[[], SSHServer]
 _ProtocolFactory = Union[_ClientFactory, _ServerFactory]
 
 _Conn = TypeVar('_Conn', 'SSHClientConnection', 'SSHServerConnection')
+_ConnSelf = TypeVar("_ConnSelf", bound="SSHConnection")
 
 class _TunnelProtocol(Protocol):
     """Base protocol for connections to tunnel SSH over"""
@@ -893,7 +894,7 @@ class SSHConnection(SSHPacketHandler, asyncio.Protocol):
 
         self._disable_trivial_auth = False
 
-    async def __aenter__(self) -> 'SSHConnection':
+    async def __aenter__(self: _ConnSelf) -> _ConnSelf:
         """Allow SSHConnection to be used as an async context manager"""
 
         return self


### PR DESCRIPTION
This makes it so that when using a subclass as a context manager like so:

```py
async with await asyncssh.connect(...) as con:
```

the `con` variable has the type `SSHClientConnection` instead of simply `SSHConnection`.

This is equivalent to the [`typing.Self` type introduced in Python 3.11](https://docs.python.org/3.11/library/typing.html#typing.Self), but backwards compatible.