### PR TITLE
Treat ProxyJump as a list not a single value

### DIFF
--- a/asyncssh/config.py
+++ b/asyncssh/config.py
@@ -554,7 +554,7 @@ class SSHClientConfig(SSHConfig):
         ('PreferredAuthentications',        SSHConfig._set_string),
         ('Port',                            SSHConfig._set_int),
         ('ProxyCommand',                    SSHConfig._set_string_list),
-        ('ProxyJump',                       SSHConfig._set_string),
+        ('ProxyJump',                       SSHConfig._set_string_list),
         ('PubkeyAuthentication',            SSHConfig._set_bool),
         ('RekeyLimit',                      SSHConfig._set_rekey_limits),
         ('RemoteCommand',                   SSHConfig._set_string),

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -362,6 +362,26 @@ class _TestTCPForwarding(_CheckForwarding):
             os.remove('.ssh/config')
 
     @asynctest
+    async def test_proxy_jump_multiple_jumps(self):
+        """Test connecting using ProxyJump with multiple hosts"""
+
+        write_file(
+            ".ssh/config",
+            "Host target\n"
+            "  Hostname localhost\n"
+            f"  Port {self._server_port}\n"
+            f"  ProxyJump localhost:{self._server_port} localhost:{self._server_port}\n"
+            "IdentityFile ckey\n",
+            "w",
+        )
+
+        try:
+            async with self.connect(host="target", username="ckey"):
+                pass
+        finally:
+            os.remove(".ssh/config")
+
+    @asynctest
     async def test_proxy_jump_encrypted_key(self):
         """Test ProxyJump with encrypted client key"""
 


### PR DESCRIPTION
The manpages and spec for OpenSSH treat ProxyJump as a list of 0 or more proxies to jump through, however the project here currently assumes exactly one value. This commit updates the config and tunnel logic to connect via multiple hosts, while still allowing for str values as users currently can manually specify a string value in a variety of cases.

fixes #635