### PR TITLE
Have SSHProcess's __aenter__ return type be Self

### DIFF
--- a/asyncssh/process.py
+++ b/asyncssh/process.py
@@ -33,7 +33,7 @@ from types import TracebackType
 from typing import Any, AnyStr, Awaitable, Callable, Dict, Generic, IO
 from typing import Iterable, List, Mapping, Optional, Set, TextIO
 from typing import Tuple, Type, TypeVar, Union, cast
-from typing_extensions import Protocol
+from typing_extensions import Protocol, Self
 
 from .channel import SSHChannel, SSHClientChannel, SSHServerChannel
 
@@ -747,7 +747,7 @@ class SSHProcess(SSHStreamSession, Generic[AnyStr]):
 
         self._paused_write_streams: Set[Optional[int]] = set()
 
-    async def __aenter__(self) -> 'SSHProcess[AnyStr]':
+    async def __aenter__(self) -> Self:
         """Allow SSHProcess to be used as an async context manager"""
 
         return self


### PR DESCRIPTION
Set the return type of `SSHProcess.__aenter__` to be `Self`.

Without this a `SSHClientProcess` used in a context manager the variable type can decay to a `SSHProcess`.

I still need to support Python 3.10, which is why Self has come from `typing_extensions` and not `typing`.