### PR TITLE
Add typing default for SFTPClient.listdir

### DIFF
--- a/asyncssh/sftp.py
+++ b/asyncssh/sftp.py
@@ -5168,7 +5168,7 @@ class SFTPClient:
         Sequence[bytes]: ... # pragma: no cover
 
     @overload
-    async def listdir(self, path: FilePath) -> \
+    async def listdir(self, path: FilePath = ...) -> \
         Sequence[str]: ... # pragma: no cover
 
     async def listdir(self, path: _SFTPPath = '.') -> Sequence[BytesOrStr]:


### PR DESCRIPTION
At runtime, it's possible to call `listdir()` (i.e. without arguments) and get a `Sequence[str]` back, due to the default argument in the implementation. However, there is no `@overload` that contains 0 arguments, so mypy doesn't think that it's possible.

This adds a simple overload for that case.