### PR TITLE
Wip keep server host cert

### DIFF
--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -1222,10 +1222,9 @@ class SSHConnection(SSHPacketHandler, asyncio.Protocol):
         return cert.key
 
     def _validate_host_key(self, host: str, addr: str, port: int,
-                           key_data: bytes) -> Tuple[SSHCertificate, SSHKey]:
+                           key_data: bytes) -> Tuple[Optional[SSHCertificate], SSHKey]:
         """Validate and return a trusted host key"""
 
-        cert = None
         try:
             cert = decode_ssh_certificate(key_data)
         except KeyImportError:
@@ -1255,7 +1254,7 @@ class SSHConnection(SSHPacketHandler, asyncio.Protocol):
                                                             port, key):
                     raise ValueError('Host key is not trusted')
 
-            return cert, key
+            return None, key
 
         raise ValueError('Unable to decode host key')
 

--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -1222,7 +1222,7 @@ class SSHConnection(SSHPacketHandler, asyncio.Protocol):
         return cert.key
 
     def _validate_host_key(self, host: str, addr: str, port: int,
-                           key_data: bytes) -> tuple[SSHCertificate, SSHKey]:
+                           key_data: bytes) -> Tuple[SSHCertificate, SSHKey]:
         """Validate and return a trusted host key"""
 
         cert = None
@@ -1232,10 +1232,10 @@ class SSHConnection(SSHPacketHandler, asyncio.Protocol):
             pass
         else:
             if cert.is_x509_chain:
-                return self._validate_x509_host_certificate_chain(
+                return cert, self._validate_x509_host_certificate_chain(
                     host, cast(SSHX509CertificateChain, cert))
             else:
-                return self._validate_openssh_host_certificate(
+                return cert, self._validate_openssh_host_certificate(
                     host, addr, port, cast(SSHOpenSSHCertificate, cert))
 
         try:


### PR DESCRIPTION
What do you think about being able to keep and consult the certificate of the host server?

Personally, I use it to make sure that the host corresponds to the right IP (with several hosts having the same certificate authority)