### PR TITLE
Store references to tasks

### DIFF
--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -2761,7 +2761,8 @@ class SSHConnection(SSHPacketHandler, asyncio.Protocol):
             await self._agent.wait_closed()
 
         await self._close_event.wait()
-        await asyncio.gather(*self._tasks, return_exceptions=True)
+        if self._tasks:
+            await asyncio.wait(self._tasks)
 
     def disconnect(self, code: int, reason: str,
                    lang: str = DEFAULT_LANG) -> None:


### PR DESCRIPTION
closes #716 
As discussed, `SSHConnection` now has a `_tasks` attribute. Created tasks are stored in it and removed when they are done.
When `wait_closed` is called, all running tasks are awaited.
What i am unsure about: should aborting the connection cancel all running tasks?  The idea here is that there needs to be a way to stop tasks that never finish. The user can try to close the connection gracefully, wait for it to close with a timeout and abort the connection if the timeout is exceeded.
The `abort()` method itself seems to be the right place to cancel all tasks, as `_force_close()` and `_cleanup()` are also called in a normal close/disconnect operation, so cancelling all tasks there would make awaiting them pointless