### PR TITLE
Allow more flexibility in specifing env values

### DIFF
--- a/asyncssh/misc.py
+++ b/asyncssh/misc.py
@@ -142,7 +142,7 @@ def encode_env(env: Env) -> Iterator[Tuple[bytes, bytes]]:
     """Convert environemnt dict or list to bytes-based dictionary"""
 
     env = cast(Sequence[Tuple[BytesOrStr, BytesOrStr]],
-               env.items() if isinstance(env, dict) else env)
+               env.items() if hasattr(env, 'items') else env)
 
     try:
         for item in env:


### PR DESCRIPTION
Instead of checking is it instance of dict check that it has "items" attribute. 

This way will work with any dict like object