### PR TITLE
Support for SSH-1.99 SSH Identification String from Client

### DIFF
--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -1550,8 +1550,7 @@ class SSHConnection(SSHPacketHandler, asyncio.Protocol):
 
         self._inpbuf = self._inpbuf[idx+1:]
 
-        if (version.startswith(b'SSH-2.0-') or
-                (self.is_client() and version.startswith(b'SSH-1.99-'))):
+        if version.startswith(b'SSH-2.0-') or version.startswith(b'SSH-1.99-'):
             if len(version) > _MAX_VERSION_LINE_LEN:
                 self._force_close(ProtocolError('Version too long'))
 


### PR DESCRIPTION
This change addresses #777 by dropping the `self.is_client()` condition when checking for `SSH-1.99` in the protoversion, thereby allowing it to apply to both client and server instances.

https://github.com/ronf/asyncssh/blob/d2812902357a64d5dc9ce8fe71b6ce3bc1b159e7/asyncssh/connection.py#L1553-L1554
