### PR TITLE
Skip directories within ~/.ssh/config.d

### DIFF
--- a/asyncssh/config.py
+++ b/asyncssh/config.py
@@ -146,7 +146,7 @@ class SSHConfig:
             else:
                 path = self._default_path
 
-            paths = list(path.glob(pattern))
+            paths = list(p for p in path.glob(pattern) if p.is_file())
 
             if not paths:
                 logger.debug1(f'Config pattern "{pattern}" matched no files')


### PR DESCRIPTION
close #784

Only parse files within the ~/.ssh/config.d directory, ignoring subdirectories. This conforms to the behaviour of ssh implementations that ignore `config.d` subdirs.