### PR TITLE
Fix pre-auth banner decoding failure on invalid UTF-8 characters

### DIFF
--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -2638,8 +2638,8 @@ class SSHConnection(SSHPacketHandler, asyncio.Protocol):
         packet.check_end()
 
         try:
-            msg = msg_bytes.decode('utf-8')
-            lang = lang_bytes.decode('ascii')
+            msg = msg_bytes.decode('utf-8', errors='replace')
+            lang = lang_bytes.decode('ascii', errors='replace')
         except UnicodeDecodeError:
             raise ProtocolError('Invalid userauth banner') from None
 


### PR DESCRIPTION
The client-side processing of SSH userauth banner messages was using strict UTF-8 decoding (the Python default), which caused a ProtocolError to be raised whenever the server sent a banner containing non-UTF-8 bytes. This happened even when users specified encoding='utf-8' and errors='replace' in their connection options, as these parameters were not being applied to the internal banner decoding logic.

This change adds errors='replace' to both the UTF-8 decoding of the banner message and the ASCII decoding of the language tag. Invalid bytes will now be replaced with the Unicode replacement character (U+FFFD) instead of causing the connection to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)