### PR TITLE
use context managers with aiofiles open

### DIFF
--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1210,10 +1210,9 @@ class _TestAsyncFileRedirection(_TestProcess):
         with open('stdin', 'w') as file:
             file.write(data)
 
-        file = await aiofiles.open('stdin', 'r')
-
-        async with self.connect() as conn:
-            result = await conn.run('echo', stdin=file)
+        async with aiofiles.open('stdin', 'r') as file:
+            async with self.connect() as conn:
+                result = await conn.run('echo', stdin=file)
 
         self.assertEqual(result.stdout, data)
         self.assertEqual(result.stderr, data)
@@ -1227,10 +1226,9 @@ class _TestAsyncFileRedirection(_TestProcess):
         with open('stdin', 'wb') as file:
             file.write(data)
 
-        file = await aiofiles.open('stdin', 'rb')
-
-        async with self.connect() as conn:
-            result = await conn.run('echo', stdin=file, encoding=None)
+        async with aiofiles.open('stdin', 'rb') as file:
+            async with self.connect() as conn:
+                result = await conn.run('echo', stdin=file, encoding=None)
 
         self.assertEqual(result.stdout, data)
         self.assertEqual(result.stderr, data)
@@ -1241,10 +1239,9 @@ class _TestAsyncFileRedirection(_TestProcess):
 
         data = str(id(self))
 
-        file = await aiofiles.open('stdout', 'w')
-
-        async with self.connect() as conn:
-            result = await conn.run('echo', input=data, stdout=file)
+        async with aiofiles.open('stdout', 'w') as file:
+            async with self.connect() as conn:
+                result = await conn.run('echo', input=data, stdout=file)
 
         with open('stdout') as file:
             stdout_data = file.read()
@@ -1275,11 +1272,10 @@ class _TestAsyncFileRedirection(_TestProcess):
 
         data = str(id(self)).encode() + b'\xff'
 
-        file = await aiofiles.open('stdout', 'wb')
-
-        async with self.connect() as conn:
-            result = await conn.run('echo', input=data, stdout=file,
-                                    encoding=None)
+        async with aiofiles.open('stdout', 'wb') as file:
+            async with self.connect() as conn:
+                result = await conn.run('echo', input=data, stdout=file,
+                                        encoding=None)
 
         with open('stdout', 'rb') as file:
             stdout_data = file.read()
@@ -1297,11 +1293,10 @@ class _TestAsyncFileRedirection(_TestProcess):
         with open('stdin', 'w') as file:
             file.write(data)
 
-        file = await aiofiles.open('stdin', 'r')
-
-        async with self.connect() as conn:
-            result = await conn.run('delay', stdin=file,
-                                    stderr=asyncssh.DEVNULL)
+        async with aiofiles.open('stdin', 'r') as file:
+            async with self.connect() as conn:
+                result = await conn.run('delay', stdin=file,
+                                        stderr=asyncssh.DEVNULL)
 
         self.assertEqual(result.stdout, data)
 


### PR DESCRIPTION
to make the tests more explicit and eliminate possible race conditions

---

This pull-request is triggered by a test case failure on Fedora Rawhide, i.e. when packaging asyncssh 2.22.0:

```
Test validation of X.509 self-signed certificate ... ok
======================================================================
FAIL: test_stdout_aiofile (tests.test_process._TestAsyncFileRedirection.test_stdout_aiofile)
Test with stdout redirected to an aiofile
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/builddir/build/BUILD/python-asyncssh-2.22.0-build/asyncssh-2.22.0/tests/util.py", line 92, in async_wrapper
    return self.loop.run_until_complete(coro(self, *args, **kwargs))
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.14/asyncio/base_events.py", line 719, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/builddir/build/BUILD/python-asyncssh-2.22.0-build/asyncssh-2.22.0/tests/test_process.py", line 1252, in test_stdout_aiofile
    self.assertEqual(stdout_data, data)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
AssertionError: '' != '140735626508016'
+ 140735626508016
----------------------------------------------------------------------
Ran 1727 tests in 327.287s
FAILED (failures=1, skipped=26)
```
https://kojipkgs.fedoraproject.org//work/tasks/7459/140687459/build.log
https://koji.fedoraproject.org/koji/taskinfo?taskID=140687459

I couldn't reproduce the issue locally, on Fedora 43, although the aiofiles version is the same:

```
python3-aiofiles-25.1.0-2.fc44.noarch
```
https://kojipkgs.fedoraproject.org//work/tasks/7459/140687459/root.log


Looking at the code, invoking `aiofiles.open` from a context manager arguably is more idiomatic and explicit, anyways, thus, the code change seems worthwhile, in any case.

I tested the change with the fedora rawhide build systems and all tests succeed:

- https://koji.fedoraproject.org/koji/taskinfo?taskID=140690280 (just the affected test case patched)
- https://koji.fedoraproject.org/koji/taskinfo?taskID=140691830 (full patch from this pull-request)
- https://koji.fedoraproject.org/koji/taskinfo?taskID=140692451 (as before, but forcing ppc64le target, as in the failing run)

I'm not familiar with the internals of aiofiles, but since it uses a thread pool internally, a race condition is plausible.
The aiofiles issue tracker has a few tickets about people having issues invoken open outside of a context manager, which might or might not be related.

Also, CI systems often are more loaded than developer systems, thus a failure may be more likely in such an environment.

NB: For portable python packages, the fedora build system select a host at random, i.e. the binary package is built at random on aarch64, x86_64, ppc64le etc. systems.

 