### PR TITLE
tunnel - reload config

### DIFF
--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -438,7 +438,7 @@ async def _open_tunnel(tunnels: object, options: _Options,
             last_conn = conn
             conn = await connect(host, port, username=username,
                                  passphrase=options.passphrase, tunnel=conn,
-                                 config=config, reload=True)
+                                 config=config, reload=False)
             conn.set_tunnel(last_conn)
 
             if options.canonicalize_hostname != 'always':

--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -459,7 +459,10 @@ async def _connect(options: _Options, config: DefTuple[ConfigPaths],
 
     canon_host = await _canonicalize_host(loop, options)
 
-    host = canon_host if canon_host else options.host
+    if isinstance(options.config, SSHServerConfig):
+        host = canon_host if canon_host else options.host
+    else:
+        host = canon_host if canon_host else options.config._orig_host
     canonical = bool(canon_host)
     final = options.config.has_match_final()
 

--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -438,7 +438,7 @@ async def _open_tunnel(tunnels: object, options: _Options,
             last_conn = conn
             conn = await connect(host, port, username=username,
                                  passphrase=options.passphrase, tunnel=conn,
-                                 config=config)
+                                 config=config, reload=True)
             conn.set_tunnel(last_conn)
 
             if options.canonicalize_hostname != 'always':

--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -438,7 +438,7 @@ async def _open_tunnel(tunnels: object, options: _Options,
             last_conn = conn
             conn = await connect(host, port, username=username,
                                  passphrase=options.passphrase, tunnel=conn,
-                                 config=config, reload=False)
+                                 config=config)
             conn.set_tunnel(last_conn)
 
             if options.canonicalize_hostname != 'always':

--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -460,9 +460,12 @@ async def _connect(options: _Options, config: DefTuple[ConfigPaths],
     canon_host = await _canonicalize_host(loop, options)
 
     if isinstance(options.config, SSHServerConfig):
-        host = canon_host if canon_host else options.host
+        host = options.host
     else:
-        host = canon_host if canon_host else options.config._orig_host
+        host = options.config._orig_host
+
+    host = canon_host if canon_host else host
+
     canonical = bool(canon_host)
     final = options.config.has_match_final()
 

--- a/tests/server.py
+++ b/tests/server.py
@@ -133,7 +133,7 @@ class ServerTestCase(AsyncTestCase):
         skey_ecdsa.write_public_key('skey_ecdsa.pub')
 
         skey_cert = skey.generate_host_certificate(
-            skey, 'name', principals=['127.0.0.1', 'localhost'])
+            skey, 'name', principals=['127.0.0.1', '127.0.0.2', '127.0.0.3', 'localhost'])
         skey_cert.write_certificate('skey-cert.pub')
 
         skey_ecdsa_cert = skey_ecdsa.generate_host_certificate(

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -247,6 +247,17 @@ class _UpstreamForwardingServer(Server):
 
         return self._upstream_conn
 
+class _JumpServer(Server):
+    def __init__(self, remote_port):
+        self._remote_port = remote_port
+
+    def begin_auth(self, username):
+        """user jumper is allowed to use this server"""
+        return username != "jumper"
+
+    def connection_requested(self, dest_host, dest_port, orig_host, orig_port):
+        return dest_port == self._remote_port
+
 
 class _CheckForwarding(ServerTestCase):
     """Utility functions for AsyncSSH forwarding unit tests"""
@@ -384,6 +395,12 @@ class _TestTCPForwarding(_CheckForwarding):
         """Test connecting a tunnneled SSH connection using ProxyJump
         with a User
         """
+        def jump_server():
+            return _JumpServer(self._server_port)
+
+
+        jump_listener = await self.create_server(jump_server)
+        jump_port = jump_listener.get_port()
 
         write_file('.ssh/config', 'Host target\n'
                    '  Hostname localhost\n'
@@ -392,7 +409,7 @@ class _TestTCPForwarding(_CheckForwarding):
                     '\n'
                    f'Host jump\n'
                    f'  Hostname localhost\n'
-                   f'  Port {self._server_port}\n'
+                   f'  Port {jump_port}\n'
                    f'  User jumper\n'
                    'IdentityFile ckey\n',
                   'w')
@@ -401,7 +418,8 @@ class _TestTCPForwarding(_CheckForwarding):
                 pass
         finally:
             os.remove('.ssh/config')
-
+        jump_listener.close()
+        await jump_listener.wait_closed()
 
     @asynctest
     async def test_proxy_jump_multiple(self):

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -397,7 +397,9 @@ class _TestTCPForwarding(_CheckForwarding):
         """
         import logging
         logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
+        logging.getLogger('asyncssh').setLevel(logging.DEBUG)
         asyncssh.set_log_level('DEBUG')
+        asyncssh.set_debug_level(3)
 
         def jump_server():
             return _JumpServer(self._server_port)

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -380,6 +380,30 @@ class _TestTCPForwarding(_CheckForwarding):
             os.remove('.ssh/config')
 
     @asynctest
+    async def test_proxy_jump_user(self):
+        """Test connecting a tunnneled SSH connection using ProxyJump
+        with a User
+        """
+
+        write_file('.ssh/config', 'Host target\n'
+                   '  Hostname localhost\n'
+                   f'  Port {self._server_port}\n'
+                   f'  ProxyJump jump\n'
+                    '\n'
+                   f'Host jump\n'
+                   f'  Hostname localhost\n'
+                   f'  Port {self._server_port}\n'
+                   f'  User jumper\n'
+                   'IdentityFile ckey\n',
+                  'w')
+        try:
+            async with self.connect(host='target', username='ckey'):
+                pass
+        finally:
+            os.remove('.ssh/config')
+
+
+    @asynctest
     async def test_proxy_jump_multiple(self):
         """Test connecting a tunnneled SSH connection using ProxyJump"""
 

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -395,19 +395,11 @@ class _TestTCPForwarding(_CheckForwarding):
         """Test connecting a tunnneled SSH connection using ProxyJump
         with a User
         """
-        import logging
-        logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
-        logging.getLogger('asyncssh').setLevel(logging.DEBUG)
-        asyncssh.set_log_level('DEBUG')
-        asyncssh.set_debug_level(3)
-
         def jump_server():
             return _JumpServer(self._server_port)
 
-
         jump_listener = await self.create_server(jump_server)
         jump_port = jump_listener.get_port()
-
 
         write_file('.ssh/config',
 f"""

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -395,6 +395,10 @@ class _TestTCPForwarding(_CheckForwarding):
         """Test connecting a tunnneled SSH connection using ProxyJump
         with a User
         """
+        import logging
+        logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
+        asyncssh.set_log_level('DEBUG')
+
         def jump_server():
             return _JumpServer(self._server_port)
 
@@ -402,17 +406,21 @@ class _TestTCPForwarding(_CheckForwarding):
         jump_listener = await self.create_server(jump_server)
         jump_port = jump_listener.get_port()
 
-        write_file('.ssh/config', 'Host target\n'
-                   '  Hostname localhost\n'
-                   f'  Port {self._server_port}\n'
-                   f'  ProxyJump jump\n'
-                    '\n'
-                   f'Host jump\n'
-                   f'  Hostname localhost\n'
-                   f'  Port {jump_port}\n'
-                   f'  User jumper\n'
-                   'IdentityFile ckey\n',
-                  'w')
+
+        write_file('.ssh/config',
+f"""
+Host jump
+        HostName 127.0.0.3
+        Port {jump_port}
+        User jumper
+
+Host target
+        Hostname 127.0.0.2
+        Port {self._server_port}
+
+Match final host 127.0.0.2
+        ProxyJump jump
+""".encode())
         try:
             async with self.connect(host='target', username='ckey'):
                 pass


### PR DESCRIPTION
This change fixes an issue when having using alias for tunnel hosts.
The ssh configuration has to be reloaded for the tunnel (alias) to evaluate to the proper values (e.g. User)

I think the unit test needs some additional work, I was unable to assert on something due to lack of values.
It'd be great if it was possible to test the server for logins for this.

e.g.
```python
assert sorted(server.logins) == sorted(["jumper","ckey"])
```