### PR TITLE
fix: ensure file handle is closed in update_xauth on exception

### DIFF
--- a/asyncssh/x11.py
+++ b/asyncssh/x11.py
@@ -491,19 +491,20 @@ async def update_xauth(auth_path: Optional[str], host: str, dpynum: str,
     if not new_file:
         raise ValueError('Unable to acquire Xauthority lock')
 
-    new_entry = SSHXAuthorityEntry(XAUTH_FAMILY_HOSTNAME, host,
-                                   dpynum, auth_proto, auth_data)
+    try:
+        new_entry = SSHXAuthorityEntry(XAUTH_FAMILY_HOSTNAME, host,
+                                       dpynum, auth_proto, auth_data)
 
-    new_file.write(bytes(new_entry))
+        new_file.write(bytes(new_entry))
 
-    for entry in walk_xauth(auth_path):
-        if (entry.family != new_entry.family or entry.addr != new_entry.addr or
-                entry.dpynum != new_entry.dpynum):
-            new_file.write(bytes(entry))
+        for entry in walk_xauth(auth_path):
+            if (entry.family != new_entry.family or entry.addr != new_entry.addr or
+                    entry.dpynum != new_entry.dpynum):
+                new_file.write(bytes(entry))
 
-    new_file.close()
-
-    os.replace(new_auth_path, auth_path)
+        os.replace(new_auth_path, auth_path)
+    finally:
+        new_file.close()
 
 
 async def create_x11_client_listener(loop: asyncio.AbstractEventLoop,

--- a/asyncssh/x11.py
+++ b/asyncssh/x11.py
@@ -491,20 +491,19 @@ async def update_xauth(auth_path: Optional[str], host: str, dpynum: str,
     if not new_file:
         raise ValueError('Unable to acquire Xauthority lock')
 
-    try:
+    with new_file:
         new_entry = SSHXAuthorityEntry(XAUTH_FAMILY_HOSTNAME, host,
                                        dpynum, auth_proto, auth_data)
 
         new_file.write(bytes(new_entry))
 
         for entry in walk_xauth(auth_path):
-            if (entry.family != new_entry.family or entry.addr != new_entry.addr or
+            if (entry.family != new_entry.family or
+                    entry.addr != new_entry.addr or
                     entry.dpynum != new_entry.dpynum):
                 new_file.write(bytes(entry))
 
         os.replace(new_auth_path, auth_path)
-    finally:
-        new_file.close()
 
 
 async def create_x11_client_listener(loop: asyncio.AbstractEventLoop,


### PR DESCRIPTION
## Problem
The `update_xauth` function in `x11.py` opens a file but doesn't properly close it if an exception occurs during write operations or `walk_xauth`. This can lead to resource leaks, especially in long-running SSH servers.

## Solution
Wrap the file operations in a try-finally block to ensure the file handle is always closed, even if an exception is raised.

## Impact
- Prevents file descriptor leaks in X11 forwarding
- Improves reliability for long-running SSH servers
- No functional changes to the logic