### PR TITLE
Fix NameError in PQDH when handling invalid algorithms

### DIFF
--- a/asyncssh/crypto/pq.py
+++ b/asyncssh/crypto/pq.py
@@ -59,7 +59,7 @@ class PQDH:
             self.ciphertext_bytes, self.secret_bytes, \
             oqs_name = _pq_algs[alg_name]
         except KeyError: # pragma: no cover, other algs not registered
-            raise ValueError(f'Unknown PQ algorithm {oqs_name}') from None
+            raise ValueError(f'Unknown PQ algorithm {alg_name.decode()}') from None
 
         if not hasattr(_oqs, 'OQS_' + oqs_name + '_keypair'): # pragma: no cover
             oqs_name += '_ipd'

--- a/tests/test_kex.py
+++ b/tests/test_kex.py
@@ -650,3 +650,9 @@ class _TestKex(AsyncTestCase):
 
         client_conn.close()
         server_conn.close()
+
+    def test_invalid_pq_alg(self):
+        """Test providing an invalid PQ algorithm"""
+
+        with self.assertRaisesRegex(ValueError, 'Unknown PQ algorithm invalid'):
+            PQDH(b'invalid')


### PR DESCRIPTION
Fixed a potential NameError in PQDH.__init__ when an invalid algorithm is provided.

The current implementation tries to use `oqs_name` inside the KeyError handler before it's actually assigned in the try block. This leads to a NameError that masks the intended ValueError about the unknown algorithm. 

Switched to using `alg_name.decode()` in the error message to ensure it's both accurate and helpful for debugging configuration issues. I also added a test case in `tests/test_kex.py` to verify the fix and prevent regressions.