### PR TITLE
Save and restore matching state and line number across include

### DIFF
--- a/asyncssh/config.py
+++ b/asyncssh/config.py
@@ -136,6 +136,8 @@ class SSHConfig:
         # pylint: disable=unused-argument
 
         old_path = self._path
+        old_matching = self._matching
+        old_line_no = self._line_no
 
         for pattern in args:
             path = Path(pattern).expanduser()
@@ -155,6 +157,8 @@ class SSHConfig:
                 self.parse(path)
 
         self._path = old_path
+        self._matching = old_matching
+        self._line_no = old_line_no
         args.clear()
 
     def _match(self, option: str, args: List[str]) -> None:


### PR DESCRIPTION
This was my fix to #811. ~I didn't test this particular version yet, though.~ I did now, on top of 2.22.0, seemed to work.