### PR TITLE
feat: add pre commit config and fix issues

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -5,7 +5,22 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+        python-version: ["3.10"]
+    steps:
+      - name: Checkout asyncssh
+        uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - name: Run checks
+        run: uvx prek run --all-files
+
   run-tests:
+    needs: lint
     name: Run tests
     permissions:
       contents: read

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+ci:
+  autoupdate_schedule: monthly
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+    -   id: check-added-large-files
+    -   id: check-toml
+    -   id: check-yaml
+        args:
+        -   --unsafe
+    -   id: end-of-file-fixer
+        files: tortoise/
+    -   id: trailing-whitespace
+        exclude: '^LICENSE$'
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.2
+    hooks:
+      - id: codespell  # See pyproject.toml for args
+        additional_dependencies:
+          - tomli
+        exclude: '^docs/changes\.rst$|^\.?pylintrc$'

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-# Secuity Policy
+# Security Policy
 
 ## Supported Versions
 

--- a/asyncssh/connection.py
+++ b/asyncssh/connection.py
@@ -7630,7 +7630,7 @@ class SSHClientConnectionOptions(SSHConnectionOptions):
        :param x509_purposes: (optional)
            A list of purposes allowed in the ExtendedKeyUsage of a
            certificate used for X.509 server certificate authentication,
-           defulting to 'secureShellServer'. If this argument is explicitly
+           defaulting to 'secureShellServer'. If this argument is explicitly
            set to `None`, the server certificate's ExtendedKeyUsage will
            not be checked.
        :param username: (optional)
@@ -7878,7 +7878,7 @@ class SSHClientConnectionOptions(SSHConnectionOptions):
            the system resolver's search domains when no matches are found
            in canonical_domains, defaulting to `True`.
        :param canonicalize_max_dots: (optional)
-           Tha maximum number of dots which can appear in a hostname
+           The maximum number of dots which can appear in a hostname
            before hostname canonicalization is disabled, defaulting
            to 1. Hostnames with more than this number of dots are
            treated as already being fully qualified and passed as-is
@@ -8522,7 +8522,7 @@ class SSHServerConnectionOptions(SSHConnectionOptions):
        :param x509_purposes: (optional)
            A list of purposes allowed in the ExtendedKeyUsage of a
            certificate used for X.509 client certificate authentication,
-           defulting to 'secureShellClient'. If this argument is explicitly
+           defaulting to 'secureShellClient'. If this argument is explicitly
            set to `None`, the client certificate's ExtendedKeyUsage will
            not be checked.
        :param host_based_auth: (optional)
@@ -8712,7 +8712,7 @@ class SSHServerConnectionOptions(SSHConnectionOptions):
            the system resolver's search domains when no matches are found
            in canonical_domains, defaulting to `True`.
        :param canonicalize_max_dots: (optional)
-           Tha maximum number of dots which can appear in a hostname
+           The maximum number of dots which can appear in a hostname
            before hostname canonicalization is disabled, defaulting
            to 1. Hostnames with more than this number of dots are
            treated as already being fully qualified and passed as-is

--- a/asyncssh/misc.py
+++ b/asyncssh/misc.py
@@ -153,7 +153,7 @@ _time_units = {'': 1, 's': 1, 'm': 60, 'h': 60*60,
 
 
 def encode_env(env: Env) -> Iterator[Tuple[bytes, bytes]]:
-    """Convert environemnt dict or list to bytes-based dictionary"""
+    """Convert environment dict or list to bytes-based dictionary"""
 
     if hasattr(env, 'items'):
         env = cast(Env, env.items())
@@ -180,7 +180,7 @@ def encode_env(env: Env) -> Iterator[Tuple[bytes, bytes]]:
 
 
 def lookup_env(patterns: EnvSeq) -> Iterator[Tuple[bytes, bytes]]:
-    """Look up environemnt variables with wildcard matches"""
+    """Look up environment variables with wildcard matches"""
 
     for pattern in patterns:
         if isinstance(pattern, str):
@@ -199,7 +199,7 @@ def lookup_env(patterns: EnvSeq) -> Iterator[Tuple[bytes, bytes]]:
 
 
 def decode_env(env: Dict[bytes, bytes]) -> Iterator[Tuple[str, str]]:
-    """Convert bytes-based environemnt dict to Unicode strings"""
+    """Convert bytes-based environment dict to Unicode strings"""
 
     for key, value in env.items():
         try:

--- a/asyncssh/pkcs11.py
+++ b/asyncssh/pkcs11.py
@@ -207,7 +207,7 @@ if pkcs11_available:
         """Load PIV keys and X.509 certificates from a PKCS#11 token
 
            This function loads a list of SSH keypairs with optional X.509
-           cerificates from attached PKCS#11 security tokens. The PKCS#11
+           certificates from attached PKCS#11 security tokens. The PKCS#11
            provider must be specified, along with a user PIN if the
            tokens are set to require one.
 

--- a/asyncssh/public_key.py
+++ b/asyncssh/public_key.py
@@ -847,10 +847,10 @@ class SSHKey:
            :param user_key:
                The user's public key.
            :param subject:
-               The subject name in the certificate, expresed as a
+               The subject name in the certificate, expressed as a
                comma-separated list of X.509 `name=value` pairs.
            :param issuer: (optional)
-               The issuer name in the certificate, expresed as a
+               The issuer name in the certificate, expressed as a
                comma-separated list of X.509 `name=value` pairs. If
                not specified, the subject name will be used, creating
                a self-signed certificate.
@@ -918,10 +918,10 @@ class SSHKey:
            :param host_key:
                The host's public key.
            :param subject:
-               The subject name in the certificate, expresed as a
+               The subject name in the certificate, expressed as a
                comma-separated list of X.509 `name=value` pairs.
            :param issuer: (optional)
-               The issuer name in the certificate, expresed as a
+               The issuer name in the certificate, expressed as a
                comma-separated list of X.509 `name=value` pairs. If
                not specified, the subject name will be used, creating
                a self-signed certificate.
@@ -989,10 +989,10 @@ class SSHKey:
            :param ca_key:
                The new CA's public key.
            :param subject:
-               The subject name in the certificate, expresed as a
+               The subject name in the certificate, expressed as a
                comma-separated list of X.509 `name=value` pairs.
            :param issuer: (optional)
-               The issuer name in the certificate, expresed as a
+               The issuer name in the certificate, expressed as a
                comma-separated list of X.509 `name=value` pairs. If
                not specified, the subject name will be used, creating
                a self-signed certificate.

--- a/asyncssh/sftp.py
+++ b/asyncssh/sftp.py
@@ -3350,7 +3350,7 @@ class SFTPClientFile:
 
     @property
     def handle(self) -> bytes:
-        """Return handle or raise an error if clsoed"""
+        """Return handle or raise an error if closed"""
 
         if self._handle is None:
             raise ValueError('I/O operation on closed file')
@@ -4645,7 +4645,7 @@ class SFTPClient:
                The file attributes to use when creating the directory or
                any intermediate directories
            :param exist_ok: (optional)
-               Whether or not to raise an error if thet target directory
+               Whether or not to raise an error if the target directory
                already exists
            :type path: :class:`PurePath <pathlib.PurePath>`, `str`, or `bytes`
            :type attrs: :class:`SFTPAttrs`

--- a/asyncssh/sshsig.py
+++ b/asyncssh/sshsig.py
@@ -246,7 +246,7 @@ def create_sshsig(key: KeyPairListArg, data: BytesOrFilePath, *,
            passed in. This can be useful when signing large blocks of data
            which have already had a hash calculated on them. If set to
            `True`, the `data` argument must be a byte string of the length
-           required by the specified `hash_name`. This defualts to `False`,
+           required by the specified `hash_name`. This defaults to `False`,
            meaning that hashing will be performed on the data before signing.
        :param hash_name: (optional)
            The name of the hash algorithm to use. This can currently be
@@ -333,7 +333,7 @@ def validate_sshsig(data: BytesOrFilePath, sig: BytesOrFilePath,
            passed in. This can be useful when signing large blocks of data
            which have already had a hash calculated on them. If set to
            `True`, the `data` argument must be a byte string of the length
-           required by the specified `hash_name`. This defualts to `False`,
+           required by the specified `hash_name`. This defaults to `False`,
            meaning that hashing will be performed on the data before signing.
        :type data: `PurePath`, `str`, or `bytes`
        :type sig: `PurePath`, `str`, or `bytes`

--- a/examples/listening_client.py
+++ b/examples/listening_client.py
@@ -42,7 +42,7 @@ async def run_client() -> None:
         if server:
             await server.wait_closed()
         else:
-            print('Listener couldn\'t be opened.', file=sys.stderr)
+            print("Listener couldn't be opened.", file=sys.stderr)
 
 try:
     asyncio.run(run_client())

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -1196,7 +1196,7 @@ class _TestChannel(ServerTestCase):
 
     @asynctest
     async def test_env_invalid_str(self):
-        """Test trying to access binary envionment value as a Unicode string"""
+        """Test trying to access binary environment value as a Unicode string"""
 
         async with self.connect() as conn:
             chan, session = await _create_session(conn, 'env_str',


### PR DESCRIPTION
Fixes #819 

`prek` is a Rust implementation of `pre-commit`. Many projects, such as FastAPI, use it instead of the original `pre-commit`.